### PR TITLE
Extend breadcrumbs for the ASP.NET 4.x conceptual docset

### DIFF
--- a/aspnet/breadcrumb/toc.yml
+++ b/aspnet/breadcrumb/toc.yml
@@ -2,55 +2,10 @@
   tocHref: /
   topicHref: /
   items:
-  - name: API reference
-    tocHref: /dotnet/api/
-    topicHref: /dotnet/api/index
   - name: ASP.NET
     tocHref: /aspnet/
     topicHref: /aspnet/index
     items:
-    - name: ASP.NET AJAX
-      tocHref: /aspnet/ajax/
-      topicHref: /aspnet/ajax/index
-    - name: ASP.NET Best Practices
-      tocHref: /aspnet/aspnet/overview/web-development-best-practices/
-      topicHref: /aspnet/aspnet/overview/web-development-best-practices/index
-    - name: OWIN and Katana
-      tocHref: /aspnet/aspnet/overview/owin-and-katana/
-      topicHref: /aspnet/aspnet/overview/owin-and-katana/index
-    - name: ASP.NET Identity
-      tocHref: /aspnet/identity/
-      topicHref: /aspnet/identity/index
-    - name: ASP.NET Mobile
-      tocHref: /aspnet/mobile/
-      topicHref: /aspnet/mobile/overview
-    - name: ASP.NET MVC
-      tocHref: /aspnet/mvc/
-      topicHref: /aspnet/mvc/index
-    - name: ASP.NET SignalR
-      tocHref: /aspnet/signalr/
-      topicHref: /aspnet/signalr/index
-    - name: ASP.NET SPA
-      tocHref: /aspnet/single-page-application/
-      topicHref: /aspnet/single-page-application/index
-    - name: ASP.NET and Visual Studio
-      tocHref: /aspnet/visual-studio/
-      topicHref: /aspnet/visual-studio/index
-    - name: ASP.NET Web API
-      tocHref: /aspnet/web-api/
-      topicHref: /aspnet/web-api/index
-    - name: ASP.NET Web Forms
-      tocHref: /aspnet/web-forms/
-      topicHref: /aspnet/web-forms/index
-    - name: ASP.NET Web Pages
-      tocHref: /aspnet/web-pages/
-      topicHref: /aspnet/web-pages/index
-    - name: ASP.NET WebHooks
-      tocHref: /aspnet/webhooks/
-      topicHref: /aspnet/webhooks/index
-    - name: ASP.NET Whitepapers
-      tocHref: /aspnet/whitepapers/
-      topicHref: /aspnet/whitepapers/index
-    - name: ASP.NET Core
-      tocHref: /aspnet/core/
-      topicHref: /aspnet/core/index
+    - name: ASP.NET 4.x
+      tocHref: /aspnet/
+      topicHref: /aspnet/overview

--- a/aspnet/docfx.json
+++ b/aspnet/docfx.json
@@ -39,6 +39,7 @@
       "_navPath": "/foo",
       "_navRel": "/foo",
       "breadcrumb_path": "/aspnet/breadcrumb/toc.json",
+      "extendBreadcrumb": true,
       "ms.prod": "aspnet-framework",
       "ms.topic": "conceptual",
       "uhfHeaderId": "MSDocsHeader-DotNet",


### PR DESCRIPTION
Make the breadcrumbs TOC file more maintainable by enabling breadcrumb extension. This change also adds many more breadcrumbs to improve the overall UX.

[Internal review page](https://review.docs.microsoft.com/aspnet/overview?branch=pr-en-us-343)