### PR TITLE
Level 2 (L2) Nav removed from aspnetdocs

### DIFF
--- a/aspnet/docfx.json
+++ b/aspnet/docfx.json
@@ -42,7 +42,7 @@
       "extendBreadcrumb": true,
       "ms.prod": "aspnet-framework",
       "ms.topic": "conceptual",
-      "uhfHeaderId": "MSDocsHeader-DotNet",
+      "uhfHeaderId": [],
       "searchScope": [
         "ASP.NET"
       ],


### PR DESCRIPTION
[Internal Review - Note that Layer 2 Nav is gone](https://review.docs.microsoft.com/en-us/aspnet/overview?branch=pr-en-us-384)

Remove Level 2 (L2) Navigation which duplicates much of the new level 1 navigation.

Fixes #385 

Please note that this is for the **aspnetdocs**, repo **not** for aspnetcore.docs

- Reference to the Level 2 header removed from docfx.json