### PR TITLE
Better practice in the DI example

### DIFF
--- a/aspnet/web-api/overview/advanced/dependency-injection.md
+++ b/aspnet/web-api/overview/advanced/dependency-injection.md
@@ -89,9 +89,6 @@ Here is an implementation of **IDependencyResolver** that wraps a Unity containe
 
 [!code-csharp[Main](dependency-injection/samples/sample8.cs)]
 
-> [!NOTE]
-> If the **GetService** method cannot resolve a type, it should return **null**. If the **GetServices** method cannot resolve a type, it should return an empty collection object. Don't throw exceptions for unknown types.
-
 ## Configuring the Dependency Resolver
 
 Set the dependency resolver on the **DependencyResolver** property of the global **HttpConfiguration** object.

--- a/aspnet/web-api/overview/advanced/dependency-injection/samples/sample8.cs
+++ b/aspnet/web-api/overview/advanced/dependency-injection/samples/sample8.cs
@@ -11,7 +11,7 @@ public class UnityResolver : IDependencyResolver
     {
         if (container == null)
         {
-            throw new ArgumentNullException("container");
+            throw new ArgumentNullException(nameof(container));
         }
         this.container = container;
     }
@@ -22,9 +22,11 @@ public class UnityResolver : IDependencyResolver
         {
             return container.Resolve(serviceType);
         }
-        catch (ResolutionFailedException)
+        catch (ResolutionFailedException exception)
         {
-            return null;
+            throw new InvalidOperationException(
+                $"Unable to resolve service for type {serviceType}.",
+                exception)
         }
     }
 
@@ -34,9 +36,11 @@ public class UnityResolver : IDependencyResolver
         {
             return container.ResolveAll(serviceType);
         }
-        catch (ResolutionFailedException)
+        catch (ResolutionFailedException exception)
         {
-            return new List<object>();
+            throw new InvalidOperationException(
+                $"Unable to resolve service for type {serviceType}.",
+                exception)
         }
     }
 


### PR DESCRIPTION
Hey, I stumbled upon this when adding Unity to some legacy code in the project. Returning `null` from `GetService` does not make sense - it's generally a [bad practice](https://odetocode.com/blogs/scott/archive/2019/08/07/think-twice-before-returning-null.aspx) and is also inconsistent with how other DI tech behaves (e.g. in ASP.NET Core where similar logic throws). Returning empty list from `GetServices` is also strange and inconsistent even with `GetService`.

So I updated the sample to throw `InvalidOperationException` in both cases, which is consistent with ASP.NET Core and also just providers better diagnostics as opposed to e.g. `NullReferenceException`.