### PR TITLE
Move Web Forms events article from dotnet/docs repo

### DIFF
--- a/aspnet/toc.yml
+++ b/aspnet/toc.yml
@@ -40,6 +40,8 @@
               href: web-forms/overview/getting-started/creating-a-basic-web-forms-page.md
             - name: Code Editing ASP.NET Web Forms in Visual Studio 2013
               href: web-forms/overview/getting-started/code-editing-in-web-forms-pages.md
+            - name: "How to: Consume Events"
+              href: web-forms/overview/how-to-consume-events.md
             - name: Using Page Inspector for Visual Studio 2012 in ASP.NET Web Forms
               href: web-forms/overview/getting-started/using-page-inspector-in-a-visual-studio-11-beta-web-forms-project.md
             - name: Visual Studio 2012 Hands On Labs

--- a/aspnet/web-forms/overview/how-to-consume-events.md
+++ b/aspnet/web-forms/overview/how-to-consume-events.md
@@ -1,5 +1,8 @@
 ---
 title: "How to: Consume Events in a Web Forms Application"
+description: Learn how to handle button-click events in ASP.NET Web Forms apps.
+author: rick-anderson
+ms.author: riande
 ms.date: "03/30/2017"
 dev_langs: 
   - "csharp"

--- a/aspnet/web-forms/overview/how-to-consume-events.md
+++ b/aspnet/web-forms/overview/how-to-consume-events.md
@@ -1,15 +1,14 @@
 ---
 title: "How to: Consume Events in a Web Forms Application"
 ms.date: "03/30/2017"
-ms.technology: dotnet-standard
 dev_langs: 
   - "csharp"
   - "vb"
 helpviewer_keywords: 
-  - "events [.NET], Web Forms"
+  - "events [ASP.NET], Web Forms"
   - "Web Forms controls, and events"
-  - "event handlers [.NET], Web Forms"
-  - "events [.NET], consuming"
+  - "event handlers [ASP.NET], Web Forms"
+  - "events [ASP.NET], consuming"
   - "Web Forms, event handling"
 ms.assetid: 73bf8638-c4ec-4069-b0bb-a1dc79b92e32
 ---
@@ -46,4 +45,5 @@ A common scenario in ASP.NET Web Forms applications is to populate a webpage wit
   
 ## See also
 
-- [Events](index.md)
+- [Examine the Events Associated with Inserting, Updating, and Deleting](data-access/editing-inserting-and-deleting-data/examining-the-events-associated-with-inserting-updating-and-deleting-cs.md)
+- [Events in .NET](/dotnet/standard/index.md)

--- a/aspnet/web-forms/overview/how-to-consume-events.md
+++ b/aspnet/web-forms/overview/how-to-consume-events.md
@@ -1,0 +1,49 @@
+---
+title: "How to: Consume Events in a Web Forms Application"
+ms.date: "03/30/2017"
+ms.technology: dotnet-standard
+dev_langs: 
+  - "csharp"
+  - "vb"
+helpviewer_keywords: 
+  - "events [.NET], Web Forms"
+  - "Web Forms controls, and events"
+  - "event handlers [.NET], Web Forms"
+  - "events [.NET], consuming"
+  - "Web Forms, event handling"
+ms.assetid: 73bf8638-c4ec-4069-b0bb-a1dc79b92e32
+---
+# How to: Consume events in a Web Forms app
+
+A common scenario in ASP.NET Web Forms applications is to populate a webpage with controls, and then perform a specific action based on which control the user clicks. For example, a <xref:System.Web.UI.WebControls.Button?displayProperty=nameWithType> control raises an event when the user clicks it in the webpage. By handling the event, your application can perform the appropriate application logic for that button click.  
+  
+## Handle a button-click event on a webpage  
+  
+1. Create a ASP.NET Web Forms page (webpage) that has a <xref:System.Web.UI.WebControls.Button> control with the `OnClick` value set to the name of method that you will define in the next step.  
+  
+    ```xml  
+    <asp:Button ID="Button1" runat="server" Text="Click Me" OnClick="Button1_Click" />  
+    ```  
+  
+2. Define an event handler that matches the <xref:System.Web.UI.WebControls.Button.Click> event delegate signature and that has the name you defined for the `OnClick` value.  
+  
+    ```csharp  
+    protected void Button1_Click(object sender, EventArgs e)  
+    {  
+        // perform action  
+    }  
+    ```  
+  
+    ```vb  
+    Protected Sub Button1_Click(sender As Object, e As EventArgs) Handles Button1.Click  
+        ' perform action  
+    End Sub  
+    ```  
+  
+     The <xref:System.Web.UI.WebControls.Button.Click> event uses the <xref:System.EventHandler> class for the delegate type and the <xref:System.EventArgs> class for the event data. The ASP.NET page framework automatically generates code that creates an instance of <xref:System.EventHandler> and adds this delegate instance to the <xref:System.Web.UI.WebControls.Button.Click> event of the <xref:System.Web.UI.WebControls.Button> instance.  
+  
+3. In the event handler method that you defined in step 2, add code to perform any actions that are required when the event occurs.  
+  
+## See also
+
+- [Events](index.md)

--- a/aspnet/web-forms/overview/index.md
+++ b/aspnet/web-forms/overview/index.md
@@ -27,6 +27,7 @@ msc.type: book
         - [ASP.NET Error Handling](getting-started/getting-started-with-aspnet-45-web-forms/aspnet-error-handling.md)
     - [Creating a Basic Web Forms Page in Visual Studio 2013](getting-started/creating-a-basic-web-forms-page.md)
     - [Code Editing ASP.NET Web Forms in Visual Studio 2013](getting-started/code-editing-in-web-forms-pages.md)
+    - [How to: Consume events in a Web Forms app](how-to-consume-events.md)
     - [Using Page Inspector for Visual Studio 2012 in ASP.NET Web Forms](getting-started/using-page-inspector-in-a-visual-studio-11-beta-web-forms-project.md)
     - [Visual Studio 2012 Hands On Labs](getting-started/hands-on-labs/index.md)
 


### PR DESCRIPTION
This article is somewhat orphaned in the .NET docs repo. See https://github.com/dotnet/docs/pull/21194#discussion_r512067077.

Is this a good spot to put it in the ASP.NET Web Forms section?

[Preview link](https://review.docs.microsoft.com/en-us/aspnet/web-forms/overview/how-to-consume-events?branch=pr-en-us-461).