### PR TITLE
Fix typo in example

### DIFF
--- a/aspnet/web-api/overview/formats-and-model-binding/parameter-binding-in-aspnet-web-api.md
+++ b/aspnet/web-api/overview/formats-and-model-binding/parameter-binding-in-aspnet-web-api.md
@@ -97,7 +97,7 @@ A model binder gets raw input values from a *value provider*. This design separa
 The default value provider in Web API gets values from the route data and the query string. For example, if the URI is `http://localhost/api/values/1?location=48,-122`, the value provider creates the following key-value pairs:
 
 - id = &quot;1&quot;
-- location = &quot;48,122&quot;
+- location = &quot;48,-122&quot;
 
 (I'm assuming the default route template, which is &quot;api/{controller}/{id}&quot;.)
 


### PR DESCRIPTION
The example URI has the query string "location=48,-122" but the example of the key-value pairs extracted from this omitted the negative sign.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->