### PR TITLE
Update supported-platforms.md

### DIFF
--- a/aspnet/signalr/overview/getting-started/supported-platforms.md
+++ b/aspnet/signalr/overview/getting-started/supported-platforms.md
@@ -66,7 +66,8 @@ Applications that use SignalR in browsers must use jQuery version 1.6.4 or major
 
 SignalR can be used in the following browsers:
 
-- Microsoft Internet Explorer versions 8, 9, 10, and 11. Modern, Desktop, and Mobile versions are supported.
+- Microsoft Internet Explorer versions 11. Windows only.
+- Microsoft Edge(Chromium). Desktop and Mobile versions are supported.
 - Mozilla Firefox: current version - 1, both Windows and Mac versions.
 - Google Chrome: current version - 1, both Windows and Mac versions.
 - Safari: current version - 1, both Mac and iOS versions.


### PR DESCRIPTION
I think that the Microsoft Edge(Chromium) is supported for ASP.NET SignalR(not Core).
So it should be added to the document like ASP.NET Core SignalR.

https://docs.microsoft.com/ja-jp/aspnet/core/signalr/supported-platforms?view=aspnetcore-5.0

In addition, it should be removed the unsupported browsers like IE8 - IE10.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->