### PR TITLE
Handling .mdf file attachment errors

### DIFF
--- a/aspnet/mvc/overview/getting-started/introduction/adding-a-new-field.md
+++ b/aspnet/mvc/overview/getting-started/introduction/adding-a-new-field.md
@@ -87,7 +87,7 @@ In the **Package Manager Console**, enter the command `update-database` to creat
 
 ![](adding-a-new-field/_static/image7.png)
 
-If you get an error that indicates a table already exists and can't be created, it is probably because you ran the application after you deleted the database and before you executed `update-database`. In that case, delete the *Movies.mdf* file again and retry the `update-database` command. If you still get an error, delete the migrations folder and contents then start with the instructions at the top of this page (that is delete the *Movies.mdf* file then proceed to Enable-Migrations). If you still get an error, open SQL Server Object Explorer and remove the database from the list. If you get an error indicating "Cannot attach the file .mdf as database", remove the Initial Catalog property as part of the connection string in the web.config file.
+If you get an error that indicates a table already exists and can't be created, it is probably because you ran the application after you deleted the database and before you executed `update-database`. In that case, delete the *Movies.mdf* file again and retry the `update-database` command. If you still get an error, delete the migrations folder and contents then start with the instructions at the top of this page (that is delete the *Movies.mdf* file then proceed to Enable-Migrations). If you still get an error, open SQL Server Object Explorer and remove the database from the list. If you get an error indicating "Cannot attach the file .mdf as database", remove the Initial Catalog property as part of the connection string in the _web.config_ file.
 
 Run the application and navigate to the */Movies* URL. The seed data is displayed.
 

--- a/aspnet/mvc/overview/getting-started/introduction/adding-a-new-field.md
+++ b/aspnet/mvc/overview/getting-started/introduction/adding-a-new-field.md
@@ -87,7 +87,7 @@ In the **Package Manager Console**, enter the command `update-database` to creat
 
 ![](adding-a-new-field/_static/image7.png)
 
-If you get an error that indicates a table already exists and can't be created, it is probably because you ran the application after you deleted the database and before you executed `update-database`. In that case, delete the *Movies.mdf* file again and retry the `update-database` command. If you still get an error, delete the migrations folder and contents then start with the instructions at the top of this page (that is delete the *Movies.mdf* file then proceed to Enable-Migrations). If you still get an error, open SQL Server Object Explorer and remove the database from the list.
+If you get an error that indicates a table already exists and can't be created, it is probably because you ran the application after you deleted the database and before you executed `update-database`. In that case, delete the *Movies.mdf* file again and retry the `update-database` command. If you still get an error, delete the migrations folder and contents then start with the instructions at the top of this page (that is delete the *Movies.mdf* file then proceed to Enable-Migrations). If you still get an error, open SQL Server Object Explorer and remove the database from the list. If you get an error indicating "Cannot attach the file .mdf as database", remove the Initial Catalog property as part of the connection string in the web.config file.
 
 Run the application and navigate to the */Movies* URL. The seed data is displayed.
 


### PR DESCRIPTION
The current error handling steps do not cater for the step where the .mdf file cant attach as a database.
See answer by @davideicardi on stackoverflow post https://stackoverflow.com/questions/17012839/cannot-attach-the-file-mdf-as-database/17031891

Issue is very common to colleagues who have taken the tutorial.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->