### PR TITLE
Update LocalDB instance in getting-started-with-aspnet-45-web-forms

### DIFF
--- a/aspnet/web-forms/overview/getting-started/getting-started-with-aspnet-45-web-forms/checkout-and-payment-with-paypal/samples/sample11.xml
+++ b/aspnet/web-forms/overview/getting-started/getting-started-with-aspnet-45-web-forms/checkout-and-payment-with-paypal/samples/sample11.xml
@@ -1,1 +1,1 @@
-<add name="DefaultConnection" connectionString="Data Source=(LocalDb)\v11.0;Initial Catalog=aspnet-WingtipToys;Integrated Security=True" providerName="System.Data.SqlClient" />
+<add name="DefaultConnection" connectionString="Data Source=(LocalDb)\MSSQLLocalDB;Initial Catalog=aspnet-WingtipToys;Integrated Security=True" providerName="System.Data.SqlClient" />

--- a/aspnet/web-forms/overview/getting-started/getting-started-with-aspnet-45-web-forms/create_the_data_access_layer/samples/sample6.xml
+++ b/aspnet/web-forms/overview/getting-started/getting-started-with-aspnet-45-web-forms/create_the_data_access_layer/samples/sample6.xml
@@ -1,7 +1,7 @@
 <connectionStrings>
-<add name="DefaultConnection" connectionString="Data Source=(LocalDb)\v11.0;AttachDbFilename=|DataDirectory|\aspnet-WingtipToys-20131119102907.mdf;Initial Catalog=aspnet-WingtipToys-20131119102907;Integrated Security=True"
+<add name="DefaultConnection" connectionString="Data Source=(LocalDb)\MSSQLLocalDB;AttachDbFilename=|DataDirectory|\aspnet-WingtipToys-20131119102907.mdf;Initial Catalog=aspnet-WingtipToys-20131119102907;Integrated Security=True"
 providerName="System.Data.SqlClient" />
 <add name="WingtipToys"
-connectionString="Data Source=(LocalDB)\v11.0;AttachDbFilename=|DataDirectory|\wingtiptoys.mdf;Integrated Security=True"
+connectionString="Data Source=(LocalDB)\MSSQLLocalDB;AttachDbFilename=|DataDirectory|\wingtiptoys.mdf;Integrated Security=True"
 providerName="System.Data.SqlClient" />
 </connectionStrings>

--- a/aspnet/web-forms/overview/getting-started/getting-started-with-aspnet-45-web-forms/ui_and_navigation/samples/sample9.xml
+++ b/aspnet/web-forms/overview/getting-started/getting-started-with-aspnet-45-web-forms/ui_and_navigation/samples/sample9.xml
@@ -1,8 +1,8 @@
 <connectionStrings>
     <add name="DefaultConnection" 
-         connectionString="Data Source=(LocalDb)\v11.0;Initial Catalog=aspnet-WingtipToys-20120302100502;Integrated Security=True" 
+         connectionString="Data Source=(LocalDb)\MSSQLLocalDB;Initial Catalog=aspnet-WingtipToys-20120302100502;Integrated Security=True"
          providerName="System.Data.SqlClient" />
     <add name="WingtipToys" 
-         connectionString="Data Source=(LocalDB)\v11.0;AttachDbFilename=|DataDirectory|\wingtiptoys.mdf;Integrated Security=True" 
+         connectionString="Data Source=(LocalDB)\MSSQLLocalDB;AttachDbFilename=|DataDirectory|\wingtiptoys.mdf;Integrated Security=True"
          providerName="System.Data.SqlClient " />
   </connectionStrings>


### PR DESCRIPTION
The default instance name changed from `v11.0` in SQL Server 2012 to `MSSQLLocalDB` in 2014 and later versions.  This PR updates the instance name in the samples to avoid connection errors when using recent SQL Server LocalDB versions.

Thanks for considering,
Kevin