### PR TITLE
Suggested book URL gives soft 404

### DIFF
--- a/aspnet/web-forms/overview/deployment/web-deployment-in-the-enterprise/understanding-the-build-process.md
+++ b/aspnet/web-forms/overview/deployment/web-deployment-in-the-enterprise/understanding-the-build-process.md
@@ -204,7 +204,7 @@ This topic provided a walkthrough of how split project files are used to control
 
 ## Further Reading
 
-For a more in-depth introduction to project files and the WPP, see [Inside the Microsoft Build Engine: Using MSBuild and Team Foundation Build](http://amzn.com/0735645248) by Sayed Ibrahim Hashimi and William Bartholomew, ISBN: 978-0-7356-4524-0.
+For a more in-depth introduction to project files and the WPP, see [Inside the Microsoft Build Engine: Using MSBuild and Team Foundation Build](https://www.microsoftpressstore.com/store/inside-the-microsoft-build-engine-using-msbuild-and-9780735645240) by Sayed Ibrahim Hashimi and William Bartholomew, ISBN: 978-0-7356-4524-0.
 
 > [!div class="step-by-step"]
 > [Previous](understanding-the-project-file.md)


### PR DESCRIPTION
This URL https://www.amazon.com/0735645248 gives a soft 404. 
Thus Amazon URL is replaced with a Microsoft Press Store URL for the same ISBN.