### PR TITLE
Removed old codeplex link for Issue 23855

### DIFF
--- a/aspnet/identity/overview/extensibility/implementing-a-custom-mysql-aspnet-identity-storage-provider.md
+++ b/aspnet/identity/overview/extensibility/implementing-a-custom-mysql-aspnet-identity-storage-provider.md
@@ -56,7 +56,7 @@ Before jumping into the steps to create the MySQL storage provider, let's look a
 
 ### Data access layer classes
 
-For this example, the data access layer classes contain SQL statements for working with the tables; however, in your code you might want to use object-relational mapping (ORM) such as Entity Framework or NHibernate. In particular, your application may experience poor performance without an ORM that includes lazy loading and object caching. For more information, see [ASP.NET Identity 2.0 without Entity Framework?](https://aspnetidentity.codeplex.com/discussions/561828)
+For this example, the data access layer classes contain SQL statements for working with the tables; however, in your code you might want to use object-relational mapping (ORM) such as Entity Framework or NHibernate. In particular, your application may experience poor performance without an ORM that includes lazy loading and object caching.
 
 - [MySQLDatabase](https://github.com/aspnet/samples/blob/master/samples/aspnet/Identity/AspNet.Identity.MySQL/MySQLDatabase.cs) - contains the MySQL database connection and methods for performing database operations. UserStore and RoleStore are both instantiated with an instance of this class.
 - [RoleTable](https://github.com/aspnet/samples/blob/master/samples/aspnet/Identity/AspNet.Identity.MySQL/RoleTable.cs) - contains database operations for the table that stores roles.

--- a/aspnet/mvc/overview/getting-started/mvc-learning-sequence.md
+++ b/aspnet/mvc/overview/getting-started/mvc-learning-sequence.md
@@ -18,7 +18,6 @@ by [Rick Anderson](https://twitter.com/RickAndMSFT)
 
 - [Getting Started with ASP.NET MVC 5](introduction/getting-started.md) This 11 part series is a good place to start.
 - [Pluralsight ASP.NET MVC 5 Fundamentals](https://pluralsight.com/training/Player?author=scott-allen&amp;name=aspdotnet-mvc5-fundamentals-m1-introduction&amp;mode=live&amp;clip=0&amp;course=aspdotnet-mvc5-fundamentals) (video course)
-- [Intro to ASP.NET MVC](https://channel9.msdn.com/Series/Introduction-to-ASP-NET-MVC) by Jon Galloway and Christopher Harrison
 - [Lifecycle of an ASP.NET MVC 5 Application](lifecycle-of-an-aspnet-mvc-5-application.md) PDF document that charts the lifecycle of an ASP.NET MVC 5 app.
 
 <a id="con"></a>
@@ -56,7 +55,4 @@ The <xref:System.Web.Mvc.Html.SelectExtensions.DropDownListFor%2A>, <xref:System
 
 The workaround is to create separate enumerables, containing distinct `SelectListItem` instances, for each property in the model.
 
-For more information, see
-
-* [DropdownListFor modifies the SelectListItem collection passed to it](http://web.archive.org/web/20140902031437/http://aspnetwebstack.codeplex.com/workitem/1913)
-* [GetSelectListWithDefaultValue Modifies IEnumerable<SelectListItem> selectList](https://github.com/aspnet/AspNetWebStack/issues/271)
+For more information, see [GetSelectListWithDefaultValue Modifies IEnumerable<SelectListItem> selectList](https://github.com/aspnet/AspNetWebStack/issues/271)

--- a/aspnet/mvc/overview/older-versions-1/deployment/using-asp-net-mvc-with-different-versions-of-iis-cs.md
+++ b/aspnet/mvc/overview/older-versions-1/deployment/using-asp-net-mvc-with-different-versions-of-iis-cs.md
@@ -93,7 +93,7 @@ Older versions of IIS only map certain requests to the ASP.NET framework. The re
 
 Therefore, to get ASP.NET Routing to work, we must modify the Default route so that it includes a file extension that is mapped to the ASP.NET framework.
 
-This is done using a script named `registermvc.wsf`. It was included with the ASP.NET MVC 1 release in `C:\Program Files\Microsoft ASP.NET\ASP.NET MVC\Scripts`, but as of ASP.NET 2 this script has been moved to the ASP.NET Futures, available at [http://aspnet.codeplex.com/releases/view/39978](http://aspnet.codeplex.com/releases/view/39978).
+This is done using a script named `registermvc.wsf`. It was included with the ASP.NET MVC 1 release in `C:\Program Files\Microsoft ASP.NET\ASP.NET MVC\Scripts`, but as of ASP.NET 2 this script has been moved to the ASP.NET Futures.
 
 Executing this script registers a new .mvc extension with IIS. After you register the .mvc extension, you can modify your routes in the Global.asax file so that the routes use the .mvc extension.
 

--- a/aspnet/mvc/overview/older-versions-1/deployment/using-asp-net-mvc-with-different-versions-of-iis-vb.md
+++ b/aspnet/mvc/overview/older-versions-1/deployment/using-asp-net-mvc-with-different-versions-of-iis-vb.md
@@ -94,7 +94,7 @@ Older versions of IIS only map certain requests to the ASP.NET framework. The re
 
 Therefore, to get ASP.NET Routing to work, we must modify the Default route so that it includes a file extension that is mapped to the ASP.NET framework.
 
-This is done using a script named `registermvc.wsf`. It was included with the ASP.NET MVC 1 release in `C:\Program Files\Microsoft ASP.NET\ASP.NET MVC\Scripts`, but as of ASP.NET 2 this script has been moved to the ASP.NET Futures, available at [http://aspnet.codeplex.com/releases/view/39978](http://aspnet.codeplex.com/releases/view/39978).
+This is done using a script named `registermvc.wsf`. It was included with the ASP.NET MVC 1 release in `C:\Program Files\Microsoft ASP.NET\ASP.NET MVC\Scripts`, but as of ASP.NET 2 this script has been moved to the ASP.NET Futures.
 
 Executing this script registers a new .mvc extension with IIS. After you register the .mvc extension, you can modify your routes in the Global.asax file so that the routes use the .mvc extension.
 

--- a/aspnet/mvc/overview/older-versions-1/models-data/validation-with-the-data-annotation-validators-cs.md
+++ b/aspnet/mvc/overview/older-versions-1/models-data/validation-with-the-data-annotation-validators-cs.md
@@ -17,8 +17,6 @@ by [Microsoft](https://github.com/microsoft)
 
 In this tutorial, you learn how to use the Data Annotation validators to perform validation in an ASP.NET MVC application. The advantage of using the Data Annotation validators is that they enable you to perform validation simply by adding one or more attributes – such as the Required or StringLength attribute – to a class property.
 
-Before you can use the Data Annotation validators, you must download the Data Annotations Model Binder. You can download the Data Annotations Model Binder Sample from the CodePlex website by clicking [here](http://aspnet.codeplex.com/Release/ProjectReleases.aspx?ReleaseId=24471).
-
 It is important to understand that the Data Annotations Model Binder is not an official part of the Microsoft ASP.NET MVC framework. Although the Data Annotations Model Binder was created by the Microsoft ASP.NET MVC team, Microsoft does not offer official product support for the Data Annotations Model Binder described and used in this tutorial.
 
 ## Using the Data Annotation Model Binder

--- a/aspnet/mvc/overview/older-versions-1/models-data/validation-with-the-data-annotation-validators-vb.md
+++ b/aspnet/mvc/overview/older-versions-1/models-data/validation-with-the-data-annotation-validators-vb.md
@@ -17,8 +17,6 @@ by [Microsoft](https://github.com/microsoft)
 
 In this tutorial, you learn how to use the Data Annotation validators to perform validation in an ASP.NET MVC application. The advantage of using the Data Annotation validators is that they enable you to perform validation simply by adding one or more attributes – such as the Required or StringLength attribute – to a class property.
 
-Before you can use the Data Annotation validators, you must download the Data Annotations Model Binder. You can download the Data Annotations Model Binder Sample from the CodePlex website by clicking [here](http://aspnet.codeplex.com/Release/ProjectReleases.aspx?ReleaseId=24471).
-
 It is important to understand that the Data Annotations Model Binder is not an official part of the Microsoft ASP.NET MVC framework. Although the Data Annotations Model Binder was created by the Microsoft ASP.NET MVC team, Microsoft does not offer official product support for the Data Annotations Model Binder described and used in this tutorial.
 
 ## Using the Data Annotation Model Binder


### PR DESCRIPTION
Fixes: dotnet/AspNetCore.Docs#23855

Removing 10 links from 6 files that point to very old codeplex and code.msdn.microsoft code examples and discussions that have been discontinued.

Internal Review:
[Data access layer classes](https://review.docs.microsoft.com/en-us/aspnet/identity/overview/extensibility/implementing-a-custom-mysql-aspnet-identity-storage-provider?branch=pr-en-us-576#data-access-layer-classes)
[ASP.NET MVC DropDownListFor with SelectListItem](https://review.docs.microsoft.com/en-us/aspnet/mvc/overview/getting-started/mvc-learning-sequence?branch=pr-en-us-576#aspnet-mvc-dropdownlistfor-with-selectlistitem)
[Using ASP.NET MVC with Different Versions of IIS (C#)](https://review.docs.microsoft.com/en-us/aspnet/mvc/overview/older-versions-1/deployment/using-asp-net-mvc-with-different-versions-of-iis-cs?branch=pr-en-us-576)
[Using ASP.NET MVC with Different Versions of IIS (VB)](https://review.docs.microsoft.com/en-us/aspnet/mvc/overview/older-versions-1/deployment/using-asp-net-mvc-with-different-versions-of-iis-vb?branch=pr-en-us-576)
[Validation with the Data Annotation Validators (C#)](https://review.docs.microsoft.com/en-us/aspnet/mvc/overview/older-versions-1/models-data/validation-with-the-data-annotation-validators-cs?branch=pr-en-us-576)
[Validation with the Data Annotation Validators (VB)](https://review.docs.microsoft.com/en-us/aspnet/mvc/overview/older-versions-1/models-data/validation-with-the-data-annotation-validators-vb?branch=pr-en-us-576)

Working directly in GitHub rather than local clone of repo due to long name issues in this repo that keep the local pr from working.  Only 10 links though in this case so not a big deal.