### PR TITLE
Some code blocks language referenced CSS

### DIFF
--- a/aspnet/signalr/overview/guide-to-the-api/working-with-groups.md
+++ b/aspnet/signalr/overview/guide-to-the-api/working-with-groups.md
@@ -78,13 +78,13 @@ You can send messages to all of the members of a group or only specified members
 
 - **All** connected clients in a specified group.
 
-    [!code-css[Main](working-with-groups/samples/sample3.css)]
+    [!code-csharp[Main](working-with-groups/samples/sample3.css)]
 - All connected clients in a specified group **except the specified clients**, identified by connection ID.
 
     [!code-csharp[Main](working-with-groups/samples/sample4.cs)]
 - All connected clients in a specified group **except the calling client**.
 
-    [!code-css[Main](working-with-groups/samples/sample5.css)]
+    [!code-csharp[Main](working-with-groups/samples/sample5.css)]
 
 <a id="storedatabase"></a>
 


### PR DESCRIPTION
On the "Calling members of a group" section, 2 of the 3 code blocks had a heading of CSS instead of C#



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->