### PR TITLE
Add example of how to globally add Authorize filter using dotnet 6

### DIFF
--- a/aspnet/web-api/overview/security/authentication-and-authorization-in-aspnet-web-api.md
+++ b/aspnet/web-api/overview/security/authentication-and-authorization-in-aspnet-web-api.md
@@ -74,6 +74,12 @@ You can apply the filter globally, at the controller level, or at the level of i
 
 **Globally**: To restrict access for every Web API controller, add the **AuthorizeAttribute** filter to the global filter list:
 
+Dotnet 6 in Program.cs
+
+[!code-csharp[Main](authentication-and-authorization-in-aspnet-web-api/samples/sample2dotnet6.cs)]
+
+Asp.NetCore 3 in Startup.cs
+
 [!code-csharp[Main](authentication-and-authorization-in-aspnet-web-api/samples/sample2.cs)]
 
 **Controller**: To restrict access for a specific controller, add the filter as an attribute to the controller:

--- a/aspnet/web-api/overview/security/authentication-and-authorization-in-aspnet-web-api/samples/sample2dotnet6.cs
+++ b/aspnet/web-api/overview/security/authentication-and-authorization-in-aspnet-web-api/samples/sample2dotnet6.cs
@@ -1,0 +1,8 @@
+builder.Services.AddControllers(options =>
+{
+    var policy = new AuthorizationPolicyBuilder()
+        .RequireAuthenticatedUser()
+        .Build();
+
+    options.Filters.Add(new AuthorizeFilter(policy));
+})


### PR DESCRIPTION
I was looking for how to globally add an Authorize filter so I didn't have to use `[Authorize]` attribute on every controller and saw that this documentation page was still using old patterns. 

I added a new code sample for dotnet 6 and updated the documentation to reference that sample.

I'm not sure if these changes fit with the rest of docs guidelines to have two versions of the same code but perhaps someone more experienced can tweak this example.