### PR TITLE
[BrokenLinksH2] remove link that was inadvertently restored

### DIFF
--- a/aspnet/mvc/overview/older-versions/using-the-html5-and-jquery-ui-datepicker-popup-calendar-with-aspnet-mvc/using-the-html5-and-jquery-ui-datepicker-popup-calendar-with-aspnet-mvc-part-4.md
+++ b/aspnet/mvc/overview/older-versions/using-the-html5-and-jquery-ui-datepicker-popup-calendar-with-aspnet-mvc/using-the-html5-and-jquery-ui-datepicker-popup-calendar-with-aspnet-mvc-part-4.md
@@ -163,7 +163,6 @@ When this code runs, if the model is not null, the model's `DateTime` value is u
 
 This tutorial has covered the basics of ASP.NET templated helpers and shows you how to use the jQuery UI datepicker popup calendar in an ASP.NET MVC application. For more information, try these resources:
 
-- For information on localization, see Rajeesh's blog [JQueryUI Datepicker in ASP.NET MVC](https://www.rajeeshcv.com/2010/02/28/jqueryui-datepicker-in-asp-net-mvc/).
 - For information about jQuery UI, see [jQuery UI](http://docs.jquery.com/UI).
 - For information about how to localize the datepicker control, see [UI/Datepicker/Localization](http://docs.jquery.com/UI/Datepicker/Localization).
 - For more information about the ASP.NET MVC templates, see Brad Wilson's blog series on [ASP.NET MVC 2 Templates](http://bradwilson.typepad.com/blog/2009/10/aspnet-mvc-2-templates-part-1-introduction.html). Although the series was written for ASP.NET MVC 2, the material still applies for the current version of ASP.NET MVC.


### PR DESCRIPTION
@Rick-Anderson You removed the blog link about the jQuery UI datepicker control in early April, but the change was inadvertently restored (probably due to a mishandled merge conflict) by one of our link fixers. Our team discovered this error when reviewing the link fixes to capture the root cause of each broken link. 

The late addition of the root cause analysis, handled by someone who did not make the link fixes, has serendipitously provided a QA of the team's work. While our overall error rates so far have been quite low, I regret that we introduced this error in your content. 

I believe this PR is ready to merge. Thank you. 

