### PR TITLE
Validation: Duplicate alt-text error fixes.

### DIFF
--- a/aspnet/mvc/overview/older-versions-1/controllers-and-routing/creating-a-controller-cs.md
+++ b/aspnet/mvc/overview/older-versions-1/controllers-and-routing/creating-a-controller-cs.md
@@ -21,11 +21,11 @@ The goal of this tutorial is to explain how you can create new ASP.NET MVC contr
 
 The easiest way to create a new controller is to right-click the Controllers folder in the Visual Studio Solution Explorer window and select the **Add, Controller** menu option (see Figure 1). Selecting this menu option opens the **Add Controller** dialog (see Figure 2).
 
-[![The New Project dialog box](creating-a-controller-cs/_static/image1.jpg)](creating-a-controller-cs/_static/image1.png)
+[![Screenshot of the Visual Studio Solution Explorer window, which shows the Add and Controller options in the right-click menu.](creating-a-controller-cs/_static/image1.jpg)](creating-a-controller-cs/_static/image1.png)
 
 **Figure 01**: Adding a new controller([Click to view full-size image](creating-a-controller-cs/_static/image2.png))
 
-[![The New Project dialog box](creating-a-controller-cs/_static/image2.jpg)](creating-a-controller-cs/_static/image3.png)
+[![Screenshot of the Add Controller dialog box, which shows Default 1 Controller in the Controller Name field.](creating-a-controller-cs/_static/image2.jpg)](creating-a-controller-cs/_static/image3.png)
 
 **Figure 02**: The Add Controller dialog ([Click to view full-size image](creating-a-controller-cs/_static/image4.png))
 

--- a/aspnet/mvc/overview/older-versions-1/controllers-and-routing/creating-a-controller-vb.md
+++ b/aspnet/mvc/overview/older-versions-1/controllers-and-routing/creating-a-controller-vb.md
@@ -21,11 +21,11 @@ The goal of this tutorial is to explain how you can create new ASP.NET MVC contr
 
 The easiest way to create a new controller is to right-click the Controllers folder in the Visual Studio Solution Explorer window and select the **Add, Controller** menu option (see Figure 1). Selecting this menu option opens the **Add Controller** dialog (see Figure 2).
 
-[![The New Project dialog box](creating-a-controller-vb/_static/image1.jpg)](creating-a-controller-vb/_static/image1.png)
+[![Screenshot of the Visual Studio Solution Explorer window, which is showing the Add and Controller options in the right-click menu.](creating-a-controller-vb/_static/image1.jpg)](creating-a-controller-vb/_static/image1.png)
 
 **Figure 01**: Adding a new controller([Click to view full-size image](creating-a-controller-vb/_static/image2.png))
 
-[![The New Project dialog box](creating-a-controller-vb/_static/image2.jpg)](creating-a-controller-vb/_static/image3.png)
+[![Screenshot of the Add Controller dialog box, which is showing Default 1 Controller in the Controller Name field.](creating-a-controller-vb/_static/image2.jpg)](creating-a-controller-vb/_static/image3.png)
 
 **Figure 02**: The Add Controller dialog ([Click to view full-size image](creating-a-controller-vb/_static/image4.png))
 

--- a/aspnet/mvc/overview/older-versions-1/deployment/using-asp-net-mvc-with-different-versions-of-iis-cs.md
+++ b/aspnet/mvc/overview/older-versions-1/deployment/using-asp-net-mvc-with-different-versions-of-iis-cs.md
@@ -46,7 +46,7 @@ The request processing mode is determined by the application pool. You can deter
 
 By default, IIS is configured to support two application pools: **DefaultAppPool** and **Classic .NET AppPool**. If DefaultAppPool is selected, then your application is running in integrated request processing mode. If Classic .NET AppPool is selected, your application is running in classic request processing mode.
 
-[![The New Project dialog box](using-asp-net-mvc-with-different-versions-of-iis-cs/_static/image1.jpg)](using-asp-net-mvc-with-different-versions-of-iis-cs/_static/image1.png)
+[![Screenshot of the Edit Application dialog box, which shows that IIS is configured to run the application in integrated request processing mode.](using-asp-net-mvc-with-different-versions-of-iis-cs/_static/image1.jpg)](using-asp-net-mvc-with-different-versions-of-iis-cs/_static/image1.png)
 
 **Figure 1**: Detecting the request processing mode([Click to view full-size image](using-asp-net-mvc-with-different-versions-of-iis-cs/_static/image2.png))
 
@@ -85,7 +85,7 @@ The Default route configured in Listing 1 enables you to route URLs that look li
 
 Unfortunately, older versions of IIS won't pass these requests to the ASP.NET framework. Therefore, these requests won't get routed to a controller. For example, if you make a browser request for the URL /Home/Index then you'll get the error page in Figure 2.
 
-[![The New Project dialog box](using-asp-net-mvc-with-different-versions-of-iis-cs/_static/image2.jpg)](using-asp-net-mvc-with-different-versions-of-iis-cs/_static/image3.png)
+[![Screenshot of the Microsoft Internet Explorer window, which shows a 404 Not Found error.](using-asp-net-mvc-with-different-versions-of-iis-cs/_static/image2.jpg)](using-asp-net-mvc-with-different-versions-of-iis-cs/_static/image3.png)
 
 **Figure 2**: Receiving a 404 Not Found error([Click to view full-size image](using-asp-net-mvc-with-different-versions-of-iis-cs/_static/image4.png))
 
@@ -155,7 +155,7 @@ Here's how you enable a wildcard script map for IIS 7.0:
 6. Enter the name MVC
 7. Click the **OK** button
 
-[![The New Project dialog box](using-asp-net-mvc-with-different-versions-of-iis-cs/_static/image3.jpg)](using-asp-net-mvc-with-different-versions-of-iis-cs/_static/image5.png)
+[![Screenshot of the Internet Information Services Manager 7 point 0 window, which shows the Add Wildcard Script Map dialog box.](using-asp-net-mvc-with-different-versions-of-iis-cs/_static/image3.jpg)](using-asp-net-mvc-with-different-versions-of-iis-cs/_static/image5.png)
 
 **Figure 3**: Creating a wildcard script map with IIS 7.0([Click to view full-size image](using-asp-net-mvc-with-different-versions-of-iis-cs/_static/image6.png))
 
@@ -170,13 +170,13 @@ Follow these steps to create a wildcard script map with IIS 6.0:
 7. Uncheck the checkbox labeled **Verify that file exists**
 8. Click the **OK** button
 
-[![The New Project dialog box](using-asp-net-mvc-with-different-versions-of-iis-cs/_static/image4.jpg)](using-asp-net-mvc-with-different-versions-of-iis-cs/_static/image7.png)
+[![Screenshot of the Internet Information Services 6 point 0 window, which shows the Add slash Edit Application Extension Mapping dialog box.](using-asp-net-mvc-with-different-versions-of-iis-cs/_static/image4.jpg)](using-asp-net-mvc-with-different-versions-of-iis-cs/_static/image7.png)
 
 **Figure 4**: Creating a wildcard script map with IIS 6.0([Click to view full-size image](using-asp-net-mvc-with-different-versions-of-iis-cs/_static/image8.png))
 
 After you enable wildcard script maps, you need to modify the route table in the Global.asax file so that it includes a Root route. Otherwise, you'll get the error page in Figure 5 when you make a request for the root page of your application. You can use the modified Global.asax file in Listing 4.
 
-[![The New Project dialog box](using-asp-net-mvc-with-different-versions-of-iis-cs/_static/image5.jpg)](using-asp-net-mvc-with-different-versions-of-iis-cs/_static/image9.png)
+[![Screenshot of the Microsoft Internet Explorer window, which shows the Missing Root route error: The incoming request does not match any route.](using-asp-net-mvc-with-different-versions-of-iis-cs/_static/image5.jpg)](using-asp-net-mvc-with-different-versions-of-iis-cs/_static/image9.png)
 
 **Figure 5**: Missing Root route error([Click to view full-size image](using-asp-net-mvc-with-different-versions-of-iis-cs/_static/image10.png))
 

--- a/aspnet/mvc/overview/older-versions-1/deployment/using-asp-net-mvc-with-different-versions-of-iis-vb.md
+++ b/aspnet/mvc/overview/older-versions-1/deployment/using-asp-net-mvc-with-different-versions-of-iis-vb.md
@@ -46,7 +46,7 @@ The request processing mode is determined by the application pool. You can deter
 
 By default, IIS is configured to support two application pools: **DefaultAppPool** and **Classic .NET AppPool**. If DefaultAppPool is selected, then your application is running in integrated request processing mode. If Classic .NET AppPool is selected, your application is running in classic request processing mode.
 
-[![The New Project dialog box](using-asp-net-mvc-with-different-versions-of-iis-vb/_static/image1.jpg)](using-asp-net-mvc-with-different-versions-of-iis-vb/_static/image1.png)
+[![Screenshot of the Edit Application dialog box, which is showing that IIS is configured to run the application in integrated request processing mode.](using-asp-net-mvc-with-different-versions-of-iis-vb/_static/image1.jpg)](using-asp-net-mvc-with-different-versions-of-iis-vb/_static/image1.png)
 
 **Figure 1**: Detecting the request processing mode([Click to view full-size image](using-asp-net-mvc-with-different-versions-of-iis-vb/_static/image2.png))
 
@@ -86,7 +86,7 @@ The Default route configured in Listing 1 enables you to route URLs that look li
 
 Unfortunately, older versions of IIS won't pass these requests to the ASP.NET framework. Therefore, these requests won't get routed to a controller. For example, if you make a browser request for the URL /Home/Index then you'll get the error page in Figure 2.
 
-[![The New Project dialog box](using-asp-net-mvc-with-different-versions-of-iis-vb/_static/image2.jpg)](using-asp-net-mvc-with-different-versions-of-iis-vb/_static/image3.png)
+[![Screenshot of the Microsoft Internet Explorer window, which is showing a 404 Not Found error.](using-asp-net-mvc-with-different-versions-of-iis-vb/_static/image2.jpg)](using-asp-net-mvc-with-different-versions-of-iis-vb/_static/image3.png)
 
 **Figure 2**: Receiving a 404 Not Found error([Click to view full-size image](using-asp-net-mvc-with-different-versions-of-iis-vb/_static/image4.png))
 
@@ -156,7 +156,7 @@ Here's how you enable a wildcard script map for IIS 7.0:
 6. Enter the name MVC
 7. Click the **OK** button
 
-[![The New Project dialog box](using-asp-net-mvc-with-different-versions-of-iis-vb/_static/image3.jpg)](using-asp-net-mvc-with-different-versions-of-iis-vb/_static/image5.png)
+[![Screenshot of the Internet Information Services Manager 7 point 0 window, which is showing the Add Wildcard Script Map dialog box.](using-asp-net-mvc-with-different-versions-of-iis-vb/_static/image3.jpg)](using-asp-net-mvc-with-different-versions-of-iis-vb/_static/image5.png)
 
 **Figure 3**: Creating a wildcard script map with IIS 7.0([Click to view full-size image](using-asp-net-mvc-with-different-versions-of-iis-vb/_static/image6.png))
 
@@ -171,13 +171,13 @@ Follow these steps to create a wildcard script map with IIS 6.0:
 7. Uncheck the checkbox labeled **Verify that file exists**
 8. Click the **OK** button
 
-[![The New Project dialog box](using-asp-net-mvc-with-different-versions-of-iis-vb/_static/image4.jpg)](using-asp-net-mvc-with-different-versions-of-iis-vb/_static/image7.png)
+[![Screenshot of the Internet Information Services 6 point 0 window, which is showing the Add slash Edit Application Extension Mapping dialog box.](using-asp-net-mvc-with-different-versions-of-iis-vb/_static/image4.jpg)](using-asp-net-mvc-with-different-versions-of-iis-vb/_static/image7.png)
 
 **Figure 4**: Creating a wildcard script map with IIS 6.0([Click to view full-size image](using-asp-net-mvc-with-different-versions-of-iis-vb/_static/image8.png))
 
 After you enable wildcard script maps, you need to modify the route table in the Global.asax file so that it includes a Root route. Otherwise, you'll get the error page in Figure 5 when you make a request for the root page of your application. You can use the modified Global.asax file in Listing 4.
 
-[![The New Project dialog box](using-asp-net-mvc-with-different-versions-of-iis-vb/_static/image5.jpg)](using-asp-net-mvc-with-different-versions-of-iis-vb/_static/image9.png)
+[![Screenshot of the Microsoft Internet Explorer window, which is showing the Missing Root route error: The incoming request does not match any route.](using-asp-net-mvc-with-different-versions-of-iis-vb/_static/image5.jpg)](using-asp-net-mvc-with-different-versions-of-iis-vb/_static/image9.png)
 
 **Figure 5**: Missing Root route error([Click to view full-size image](using-asp-net-mvc-with-different-versions-of-iis-vb/_static/image10.png))
 

--- a/aspnet/mvc/overview/older-versions-1/getting-started-with-mvc/getting-started-with-mvc-part1.md
+++ b/aspnet/mvc/overview/older-versions-1/getting-started-with-mvc/getting-started-with-mvc-part1.md
@@ -48,7 +48,7 @@ Start by running Visual Web Developer 2010 Express (I'll call it "VWD" from now 
 
 Visual Web Developer is an IDE, or Integrated Developer Environment. Just like you use Microsoft Word to write documents, you'll use an IDE to create applications. There's a toolbar along the top showing various options available to you, as well as the menu you could also have used to Select File | New project.
 
-[![Microsoft Visual Web Developer 2010 Express](getting-started-with-mvc-part1/_static/image6.png)](getting-started-with-mvc-part1/_static/image5.png)
+[![Screenshot of the Microsoft Visual Web Developer 2010 Express window, which shows the Start Page.](getting-started-with-mvc-part1/_static/image6.png)](getting-started-with-mvc-part1/_static/image5.png)
 
 ## Creating Your First Application
 
@@ -58,7 +58,7 @@ You can create applications using Visual Basic or Visual C#. For now, Select Vis
 
 On the right-hand side is the Solution Explorer showing all the files and folders in your application. The big window in the middle is where you edit your code and spend most of your time. Visual Studio used a default template for the ASP.NET MVC project you just created, so you have a working application right now without doing anything! This is a simple "Hello World! project, and it is a good place to start for our application.
 
-[![Microsoft Visual Web Developer 2010 Express](getting-started-with-mvc-part1/_static/image10.png)](getting-started-with-mvc-part1/_static/image9.png)
+[![Screenshot of the Microsoft Visual Web Developer 2010 Express window, which shows the new Home Controller dot c s file is open in the code editor.](getting-started-with-mvc-part1/_static/image10.png)](getting-started-with-mvc-part1/_static/image9.png)
 
 Select the "play" button to the toolbar.
 

--- a/aspnet/mvc/overview/older-versions-1/getting-started-with-mvc/getting-started-with-mvc-part5.md
+++ b/aspnet/mvc/overview/older-versions-1/getting-started-with-mvc/getting-started-with-mvc-part5.md
@@ -39,7 +39,7 @@ Click add and the system will automatically generate the code for a View for us 
 
 Run your application and visit /Movies in the address bar. Now we've retrieved data from the database using a basic query inside the Controller and returned the data to a View that knows about Movies. That View then spins through the list of Movies and creates a table of data for us.
 
-[![Movie List - Windows Internet Explorer](getting-started-with-mvc-part5/_static/image7.png)](getting-started-with-mvc-part5/_static/image6.png)
+[![Screenshot of the Internet Explorer browser window, which shows the My Movie List with Ghostbusters 2 and Ghostbusters 3 in the list.](getting-started-with-mvc-part5/_static/image7.png)](getting-started-with-mvc-part5/_static/image6.png)
 
 We won't be implementing Edit, Details and Delete functionality with this application - so we don't need the default links that the scaffold template created for us. Open up the /Movies/Index.aspx file and remove them.
 
@@ -49,7 +49,7 @@ Here is the source code for what our updated View template should look like once
 
 It's creating links that we won't need, so we'll delete them for this example. We will keep our Create New link though, as that's next! Here's what our app looks like with that column removed.
 
-[![Movie List - Windows Internet Explorer](getting-started-with-mvc-part5/_static/image9.png)](getting-started-with-mvc-part5/_static/image8.png)
+[![Screenshot of the Internet Explorer browser window, which shows the My Movie List with the Edit, Details, and Delete links removed.](getting-started-with-mvc-part5/_static/image9.png)](getting-started-with-mvc-part5/_static/image8.png)
 
 We now have a simple listing of our movie data. However, if we click the "Create New" link, we'll get an error as it's not hooked up! Let's implement a Create Action method and enable a user to enter new movies in our database.
 

--- a/aspnet/mvc/overview/older-versions-1/models-data/creating-model-classes-with-linq-to-sql-cs.md
+++ b/aspnet/mvc/overview/older-versions-1/models-data/creating-model-classes-with-linq-to-sql-cs.md
@@ -43,13 +43,13 @@ After you create the new database, you can open the database by double-clicking 
 
 The Server Explorer window is called the Database Explorer window when using Visual Web Developer.
 
-[![Using the Server Explorer window](creating-model-classes-with-linq-to-sql-cs/_static/image5.png)](creating-model-classes-with-linq-to-sql-cs/_static/image4.png)
+[![Screenshot of the Server Explorer window, which shows that the Tables folder is highlighted in the folder hierarchy.](creating-model-classes-with-linq-to-sql-cs/_static/image5.png)](creating-model-classes-with-linq-to-sql-cs/_static/image4.png)
 
 **Figure 02**: Using the Server Explorer window ([Click to view full-size image](creating-model-classes-with-linq-to-sql-cs/_static/image6.png))
 
 We need to add one table to our database that represents our movies. Right-click the Tables folder and select the menu option **Add New Table**. Selecting this menu option opens the Table Designer (see Figure 3).
 
-[![Using the Server Explorer window](creating-model-classes-with-linq-to-sql-cs/_static/image8.png)](creating-model-classes-with-linq-to-sql-cs/_static/image7.png)
+[![Screenshot of the Microsoft Visual Studio window, which shows the Table Designer feature.](creating-model-classes-with-linq-to-sql-cs/_static/image8.png)](creating-model-classes-with-linq-to-sql-cs/_static/image7.png)
 
 **Figure 03**: The Table Designer ([Click to view full-size image](creating-model-classes-with-linq-to-sql-cs/_static/image9.png))
 

--- a/aspnet/mvc/overview/older-versions-1/models-data/creating-model-classes-with-linq-to-sql-vb.md
+++ b/aspnet/mvc/overview/older-versions-1/models-data/creating-model-classes-with-linq-to-sql-vb.md
@@ -44,13 +44,13 @@ After you create the new database, you can open the database by double-clicking 
 **The Server Explorer window is called the Database Explorer window when using Visual Web Developer.** 
 
 
-[![Using the Server Explorer window](creating-model-classes-with-linq-to-sql-vb/_static/image5.png)](creating-model-classes-with-linq-to-sql-vb/_static/image4.png)
+[![Screenshot of the Server Explorer window, which is showing that the Tables folder is highlighted in the folder hierarchy.](creating-model-classes-with-linq-to-sql-vb/_static/image5.png)](creating-model-classes-with-linq-to-sql-vb/_static/image4.png)
 
 **Figure 02**: Using the Server Explorer window ([Click to view full-size image](creating-model-classes-with-linq-to-sql-vb/_static/image6.png))
 
 We need to add one table to our database that represents our movies. Right-click the Tables folder and select the menu option **Add New Table**. Selecting this menu option opens the Table Designer (see Figure 3).
 
-[![Using the Server Explorer window](creating-model-classes-with-linq-to-sql-vb/_static/image8.png)](creating-model-classes-with-linq-to-sql-vb/_static/image7.png)
+[![Screenshot of the Microsoft Visual Studio window, which is showing the Table Designer feature.](creating-model-classes-with-linq-to-sql-vb/_static/image8.png)](creating-model-classes-with-linq-to-sql-vb/_static/image7.png)
 
 **Figure 03**: The Table Designer ([Click to view full-size image](creating-model-classes-with-linq-to-sql-vb/_static/image9.png))
 

--- a/aspnet/mvc/overview/older-versions-1/models-data/performing-simple-validation-cs.md
+++ b/aspnet/mvc/overview/older-versions-1/models-data/performing-simple-validation-cs.md
@@ -45,11 +45,11 @@ The Html.ValidationMessage() and Html.ValidationSummary() helpers are used in th
 
 Make sure that you build your application before adding a view. Otherwise, the list of classes won't appear in the **View data class** dropdown list.
 
-[![The New Project dialog box](performing-simple-validation-cs/_static/image1.jpg)](performing-simple-validation-cs/_static/image1.png)
+[![Screenshot of the Product Controller dot c s file in the code editor, which shows the right-click menu with the highlighted Add View menu item.](performing-simple-validation-cs/_static/image1.jpg)](performing-simple-validation-cs/_static/image1.png)
 
 **Figure 01**: Adding a view([Click to view full-size image](performing-simple-validation-cs/_static/image2.png))
 
-[![The New Project dialog box](performing-simple-validation-cs/_static/image2.jpg)](performing-simple-validation-cs/_static/image3.png)
+[![Screenshot of the Add View dialog box, which shows that the Create a strongly-typed view checkbox is filled.](performing-simple-validation-cs/_static/image2.jpg)](performing-simple-validation-cs/_static/image3.png)
 
 **Figure 02**: Creating a strongly-typed view ([Click to view full-size image](performing-simple-validation-cs/_static/image4.png))
 
@@ -65,7 +65,7 @@ The Html.ValidationMessage() helper is called next to each of the HTML form fiel
 
 The page in Figure 3 illustrates the error messages rendered by the validation helpers when the form is submitted with missing fields and invalid values.
 
-[![The New Project dialog box](performing-simple-validation-cs/_static/image3.jpg)](performing-simple-validation-cs/_static/image5.png)
+[![Screenshot of the Internet Explorer window, which shows the Create view with error messages resulting from fields filled with invalid values.](performing-simple-validation-cs/_static/image3.jpg)](performing-simple-validation-cs/_static/image5.png)
 
 **Figure 03**: The Create view submitted with problems ([Click to view full-size image](performing-simple-validation-cs/_static/image6.png))
 
@@ -87,7 +87,7 @@ You can modify these cascading style sheet classes, and therefore modify the app
 
 If you submit the HTML form for creating a Product, and you enter an invalid value for the price field and no value for the UnitsInStock field, then you'll get the validation messages displayed in Figure 4. Where do these validation error messages come from?
 
-[![The New Project dialog box](performing-simple-validation-cs/_static/image4.jpg)](performing-simple-validation-cs/_static/image7.png)
+[![Screenshot of the Internet Explorer window, which shows the Price and Units in Stock fields are flagging validation errors.](performing-simple-validation-cs/_static/image4.jpg)](performing-simple-validation-cs/_static/image7.png)
 
 **Figure 04**: Prebinding Validation Errors([Click to view full-size image](performing-simple-validation-cs/_static/image8.png))
 

--- a/aspnet/mvc/overview/older-versions-1/models-data/performing-simple-validation-vb.md
+++ b/aspnet/mvc/overview/older-versions-1/models-data/performing-simple-validation-vb.md
@@ -45,11 +45,11 @@ The Html.ValidationMessage() and Html.ValidationSummary() helpers are used in th
 
 Make sure that you build your application before adding a view. Otherwise, the list of classes won't appear in the **View data class** dropdown list.
 
-[![The New Project dialog box](performing-simple-validation-vb/_static/image1.jpg)](performing-simple-validation-vb/_static/image1.png)
+[![Screenshot of the Product Controller dot c s file in the code editor, which is showing the right-click menu with the highlighted Add View menu item.](performing-simple-validation-vb/_static/image1.jpg)](performing-simple-validation-vb/_static/image1.png)
 
 **Figure 01**: Adding a view([Click to view full-size image](performing-simple-validation-vb/_static/image2.png))
 
-[![The New Project dialog box](performing-simple-validation-vb/_static/image2.jpg)](performing-simple-validation-vb/_static/image3.png)
+[![Screenshot of the Add View dialog box, which is showing that the Create a strongly-typed view checkbox is filled.](performing-simple-validation-vb/_static/image2.jpg)](performing-simple-validation-vb/_static/image3.png)
 
 **Figure 02**: Creating a strongly-typed view ([Click to view full-size image](performing-simple-validation-vb/_static/image4.png))
 
@@ -65,7 +65,7 @@ The Html.ValidationMessage() helper is called next to each of the HTML form fiel
 
 The page in Figure 3 illustrates the error messages rendered by the validation helpers when the form is submitted with missing fields and invalid values.
 
-[![The New Project dialog box](performing-simple-validation-vb/_static/image3.jpg)](performing-simple-validation-vb/_static/image5.png)
+[![Screenshot of the Internet Explorer window, which is showing the Create view with error messages resulting from fields filled with invalid values.](performing-simple-validation-vb/_static/image3.jpg)](performing-simple-validation-vb/_static/image5.png)
 
 **Figure 03**: The Create view submitted with problems ([Click to view full-size image](performing-simple-validation-vb/_static/image6.png))
 
@@ -87,7 +87,7 @@ You can modify these cascading style sheet classes, and therefore modify the app
 
 If you submit the HTML form for creating a Product, and you enter an invalid value for the price field and no value for the UnitsInStock field, then you'll get the validation messages displayed in Figure 4. Where do these validation error messages come from?
 
-[![The New Project dialog box](performing-simple-validation-vb/_static/image4.jpg)](performing-simple-validation-vb/_static/image7.png)
+[![Screenshot of the Internet Explorer window, which is showing the Price and Units in Stock fields are flagging validation errors.](performing-simple-validation-vb/_static/image4.jpg)](performing-simple-validation-vb/_static/image7.png)
 
 **Figure 04**: Prebinding Validation Errors([Click to view full-size image](performing-simple-validation-vb/_static/image8.png))
 


### PR DESCRIPTION
Fixed: 

- image-alt-text-duplicated errors (duplicate alt text descriptions within an article)

This PR fixes 30 issues across 10 files and is part of ongoing Validation cleanup efforts. No other content has been edited or added.