### PR TITLE
Validation: Duplicate alt-text error fixes.

### DIFF
--- a/aspnet/web-forms/overview/older-versions-getting-started/deploying-web-site-projects/deploying-a-database-cs.md
+++ b/aspnet/web-forms/overview/older-versions-getting-started/deploying-web-site-projects/deploying-a-database-cs.md
@@ -86,7 +86,7 @@ Open Visual Studio and navigate to the `Reviews.mdf` database. If you are using 
 
 Right-click on the database name and choose the "Publish to provider" option from the context menu. This launches the Database Publishing Wizard (see Figure 5). Click Next to advance past the splash screen.
 
-[![The Database Publishing Wizard Splash Screen](deploying-a-database-cs/_static/image14.jpg)](deploying-a-database-cs/_static/image13.jpg) 
+[![Screenshot of the Database Publishing Wizard window, which shows the splash screen and the Next button to advance the wizard.](deploying-a-database-cs/_static/image14.jpg)](deploying-a-database-cs/_static/image13.jpg) 
 
 **Figure 5**: The Database Publishing Wizard Splash Screen ([Click to view full-size image](deploying-a-database-cs/_static/image15.jpg))
 
@@ -95,7 +95,7 @@ The second screen in the wizard lists the databases accessible to the Database P
 > [!NOTE]
 > If you get the error "There are no objects in database *databaseName* of the types scriptable by this wizard" when clicking Next in the screen shown in Figure 6, make sure that the path to your database file is not overly long. It has been discovered that this error can arise if the path to the database file is too long.
 
-[![The Database Publishing Wizard Splash Screen](deploying-a-database-cs/_static/image17.jpg)](deploying-a-database-cs/_static/image16.jpg) 
+[![Screenshot of the Database Publishing Wizard window, which shows a highlighted database in the database list and a filled Script all objects checkbox.](deploying-a-database-cs/_static/image17.jpg)](deploying-a-database-cs/_static/image16.jpg) 
 
 **Figure 6**: The Database Publishing Wizard Splash Screen ([Click to view full-size image](deploying-a-database-cs/_static/image18.jpg))
 
@@ -123,13 +123,13 @@ A better approach is to connect directly to the production database server using
 
 Launch SSMS and connect to your web host s database server using the information provided by your web host provider.
 
-[![Connect to Your Web Host Provider s Database Server](deploying-a-database-cs/_static/image26.jpg)](deploying-a-database-cs/_static/image25.jpg) 
+[![Screenshot of the Connect to Server dialog box, which shows the web host's data server information in the text fields.](deploying-a-database-cs/_static/image26.jpg)](deploying-a-database-cs/_static/image25.jpg) 
 
 **Figure 9**: Connect to Your Web Host Provider s Database Server ([Click to view full-size image](deploying-a-database-cs/_static/image27.jpg))
 
 Expand the Databases tab and locate your database. Click the New Query button in the upper left corner of the Toolbar, paste in the SQL commands from the script file created by the Database Publishing Wizard, and click the Execute button to run these commands on the production database server. If your script file is especially large it may take several minutes to execute the commands.
 
-[![Connect to Your Web Host Provider s Database Server](deploying-a-database-cs/_static/image29.jpg)](deploying-a-database-cs/_static/image28.jpg) 
+[![Screenshot of the Microsoft SQL Server Management Studio window, which shows the commands from the script file are executed on the production server.](deploying-a-database-cs/_static/image29.jpg)](deploying-a-database-cs/_static/image28.jpg) 
 
 **Figure 10**: Connect to Your Web Host Provider s Database Server ([Click to view full-size image](deploying-a-database-cs/_static/image30.jpg))
 

--- a/aspnet/web-forms/overview/older-versions-getting-started/deploying-web-site-projects/deploying-a-database-vb.md
+++ b/aspnet/web-forms/overview/older-versions-getting-started/deploying-web-site-projects/deploying-a-database-vb.md
@@ -86,7 +86,7 @@ Open Visual Studio and navigate to the `Reviews.mdf` database. If you are using 
 
 Right-click on the database name and choose the "Publish to provider" option from the context menu. This launches the Database Publishing Wizard (see Figure 5). Click Next to advance past the splash screen.
 
-[![The Database Publishing Wizard Splash Screen](deploying-a-database-vb/_static/image14.jpg)](deploying-a-database-vb/_static/image13.jpg) 
+[![Screenshot of the Database Publishing Wizard window, which is showing the splash screen and the Next button to advance the wizard.](deploying-a-database-vb/_static/image14.jpg)](deploying-a-database-vb/_static/image13.jpg) 
 
 **Figure 5**: The Database Publishing Wizard Splash Screen ([Click to view full-size image](deploying-a-database-vb/_static/image15.jpg))
 
@@ -95,7 +95,7 @@ The second screen in the wizard lists the databases accessible to the Database P
 > [!NOTE]
 > If you get the error "There are no objects in database *databaseName* of the types scriptable by this wizard" when clicking Next in the screen shown in Figure 6, make sure that the path to your database file is not overly long. As noted in [this discussion item](http://www.codeplex.com/sqlhost/Thread/View.aspx?ThreadId=11014) on the Database Publishing Wizard project page, this error can arise if the path to the database file is too long.
 
-[![The Database Publishing Wizard Splash Screen](deploying-a-database-vb/_static/image17.jpg)](deploying-a-database-vb/_static/image16.jpg) 
+[![Screenshot of the Database Publishing Wizard window, which is showing a highlighted database in the list and a filled Script all objects checkbox.](deploying-a-database-vb/_static/image17.jpg)](deploying-a-database-vb/_static/image16.jpg) 
 
 **Figure 6**: The Database Publishing Wizard Splash Screen ([Click to view full-size image](deploying-a-database-vb/_static/image18.jpg))
 
@@ -123,13 +123,13 @@ A better approach is to connect directly to the production database server using
 
 Launch SSMS and connect to your web host s database server using the information provided by your web host provider.
 
-[![Connect to Your Web Host Provider s Database Server](deploying-a-database-vb/_static/image26.jpg)](deploying-a-database-vb/_static/image25.jpg) 
+[![Screenshot of the Connect to Server dialog box, which is showing the web host's data server information in the text fields.](deploying-a-database-vb/_static/image26.jpg)](deploying-a-database-vb/_static/image25.jpg) 
 
 **Figure 9**: Connect to Your Web Host Provider s Database Server ([Click to view full-size image](deploying-a-database-vb/_static/image27.jpg))
 
 Expand the Databases tab and locate your database. Click the New Query button in the upper left corner of the Toolbar, paste in the SQL commands from the script file created by the Database Publishing Wizard, and click the Execute button to run these commands on the production database server. If your script file is especially large it may take several minutes to execute the commands.
 
-[![Connect to Your Web Host Provider s Database Server](deploying-a-database-vb/_static/image29.jpg)](deploying-a-database-vb/_static/image28.jpg) 
+[![Screenshot of the Microsoft SQL Server Management Studio window, which is showing the script file commands being executed on the production server.](deploying-a-database-vb/_static/image29.jpg)](deploying-a-database-vb/_static/image28.jpg) 
 
 **Figure 10**: Connect to Your Web Host Provider s Database Server ([Click to view full-size image](deploying-a-database-vb/_static/image30.jpg))
 

--- a/aspnet/web-forms/overview/older-versions-getting-started/deploying-web-site-projects/deploying-your-site-using-an-ftp-client-cs.md
+++ b/aspnet/web-forms/overview/older-versions-getting-started/deploying-web-site-projects/deploying-your-site-using-an-ftp-client-cs.md
@@ -59,7 +59,7 @@ Figure 1 shows FileZilla after the necessary files have been copied. FileZilla d
 > [!NOTE]
 > There is no harm in having the source code files on the production server, as they are ignored. ASP.NET forbids HTTP requests to source code files by default so that even if the source code files are present on the production server they are inaccessible to visitors to your website. (That is, if a user tries to visit `http://www.yoursite.com/Default.aspx.cs` they will get an error page that explains that these types of files - `.cs` files - are forbidden.)
 
-[![Use an FTP Client to Copy the Necessary Files from Your Desktop to the Web Server at the Web Host Provider](deploying-your-site-using-an-ftp-client-cs/_static/image2.png)](deploying-your-site-using-an-ftp-client-cs/_static/image1.png)
+[![Screenshot of the FileZilla FTP client, which shows that some ASP dot Net source code files were not copied to the remote server.](deploying-your-site-using-an-ftp-client-cs/_static/image2.png)](deploying-your-site-using-an-ftp-client-cs/_static/image1.png)
 
 **Figure 1**: Use an FTP Client to Copy the Necessary Files from Your Desktop to the Web Server at the Web Host Provider ([Click to view full-size image](deploying-your-site-using-an-ftp-client-cs/_static/image3.png))
 
@@ -109,7 +109,7 @@ Once you've successfully built the project, use your FTP client to copy the foll
 
 Figure 3 shows FileZilla after copying up the necessary files. As you can see, the ASP.NET source code files, such as `About.aspx.cs`, are present on both the local computer (the development environment) and the web host provider (the production environment) because code files need to be deployed when using automatic compilation.
 
-[![Use an FTP Client to Copy the Necessary Files from Your Desktop to the Web Server at the Web Host Provider](deploying-your-site-using-an-ftp-client-cs/_static/image8.png)](deploying-your-site-using-an-ftp-client-cs/_static/image7.png)
+[![Screenshot of the FileZilla FTP client window, which shows the ASP dot Net source code files have been successfully uploaded to the server.](deploying-your-site-using-an-ftp-client-cs/_static/image8.png)](deploying-your-site-using-an-ftp-client-cs/_static/image7.png)
 
 **Figure 3**: Use an FTP Client to Copy the Necessary Files from Your Desktop to the Web Server at the Web Host Provider ([Click to view full-size image](deploying-your-site-using-an-ftp-client-cs/_static/image9.png))
 

--- a/aspnet/web-forms/overview/older-versions-getting-started/deploying-web-site-projects/deploying-your-site-using-visual-studio-cs.md
+++ b/aspnet/web-forms/overview/older-versions-getting-started/deploying-web-site-projects/deploying-your-site-using-visual-studio-cs.md
@@ -50,7 +50,7 @@ You can connect to the destination website by selecting one of the four options 
 
 Most web host providers support FTP, but fewer offer FrontPage Server Extension support. For that reason, I've selected the FTP Site option and then entered the connection information as shown in Figure 2.
 
-[![Specify the Destination Website](deploying-your-site-using-visual-studio-cs/_static/image5.png)](deploying-your-site-using-visual-studio-cs/_static/image4.png)
+[![Screenshot of the Open Web Site dialog, which shows the connection information is filled into the text fields.](deploying-your-site-using-visual-studio-cs/_static/image5.png)](deploying-your-site-using-visual-studio-cs/_static/image4.png)
 
 **Figure 2**: Specify the Destination Website ([Click to view full-size image](deploying-your-site-using-visual-studio-cs/_static/image6.png))
 
@@ -95,7 +95,7 @@ Let's look at deploying the Book Reviews application using the Publish option. S
 
 There's also an option to upload the contents of the `App_Data` folder.
 
-[![Specify the Destination Website](deploying-your-site-using-visual-studio-cs/_static/image17.png)](deploying-your-site-using-visual-studio-cs/_static/image16.png)
+[![Screenshot of the Publish Web dialog, which shows the filled Delete all existing files prior to publish and Only files needed to run checkboxes.](deploying-your-site-using-visual-studio-cs/_static/image17.png)](deploying-your-site-using-visual-studio-cs/_static/image16.png)
 
 **Figure 6**: Specify the Destination Website ([Click to view full-size image](deploying-your-site-using-visual-studio-cs/_static/image18.png))
 

--- a/aspnet/web-forms/overview/older-versions-getting-started/deploying-web-site-projects/deploying-your-site-using-visual-studio-vb.md
+++ b/aspnet/web-forms/overview/older-versions-getting-started/deploying-web-site-projects/deploying-your-site-using-visual-studio-vb.md
@@ -50,7 +50,7 @@ You can connect to the destination website by selecting one of the four options 
 
 Most web host providers support FTP, but fewer offer FrontPage Server Extension support. For that reason, I've selected the FTP Site option and then entered the connection information as shown in Figure 2.
 
-[![Specify the Destination Website](deploying-your-site-using-visual-studio-vb/_static/image5.png)](deploying-your-site-using-visual-studio-vb/_static/image4.png)
+[![Screenshot of the Open Web Site dialog, which is showing the connection information is filled into the text fields.](deploying-your-site-using-visual-studio-vb/_static/image5.png)](deploying-your-site-using-visual-studio-vb/_static/image4.png)
 
 **Figure 2**: Specify the Destination Website ([Click to view full-size image](deploying-your-site-using-visual-studio-vb/_static/image6.png))
 
@@ -95,7 +95,7 @@ Let's look at deploying the Book Reviews application using the Publish option. S
 
 There's also an option to upload the contents of the `App_Data` folder.
 
-[![Specify the Destination Website](deploying-your-site-using-visual-studio-vb/_static/image17.png)](deploying-your-site-using-visual-studio-vb/_static/image16.png)
+[![Screenshot of the Publish Web dialog, which is showing the filled Delete all existing files prior to publish and Only files needed to run checkboxes.](deploying-your-site-using-visual-studio-vb/_static/image17.png)](deploying-your-site-using-visual-studio-vb/_static/image16.png)
 
 **Figure 6**: Specify the Destination Website ([Click to view full-size image](deploying-your-site-using-visual-studio-vb/_static/image18.png))
 

--- a/aspnet/web-forms/overview/older-versions-getting-started/deployment-to-a-hosting-provider/deployment-to-a-hosting-provider-deploying-to-iis-as-a-test-environment-5-of-12.md
+++ b/aspnet/web-forms/overview/older-versions-getting-started/deployment-to-a-hosting-provider/deployment-to-a-hosting-provider-deploying-to-iis-as-a-test-environment-5-of-12.md
@@ -176,13 +176,13 @@ If Visual Studio is in administrator mode, the **Output** window reports success
 
 The browser automatically opens to the Contoso University Home page running in IIS on the local computer.
 
-[![Home_page_Test](deployment-to-a-hosting-provider-deploying-to-iis-as-a-test-environment-5-of-12/_static/image18.png)](deployment-to-a-hosting-provider-deploying-to-iis-as-a-test-environment-5-of-12/_static/image17.png)
+[![Screenshot of the Internet Explorer window, which is showing the Contoso University environment indicator is Test instead of Dev.](deployment-to-a-hosting-provider-deploying-to-iis-as-a-test-environment-5-of-12/_static/image18.png)](deployment-to-a-hosting-provider-deploying-to-iis-as-a-test-environment-5-of-12/_static/image17.png)
 
 ## Testing in the Test Environment
 
 Notice that the environment indicator shows "(Test)" instead of "(Dev)", which shows that the *Web.config* transformation for the environment indicator was successful.
 
-[![Home_page_Test](deployment-to-a-hosting-provider-deploying-to-iis-as-a-test-environment-5-of-12/_static/image20.png)](deployment-to-a-hosting-provider-deploying-to-iis-as-a-test-environment-5-of-12/_static/image19.png)
+[![Screenshot of the Internet Explorer window, which shows the Contoso University environment indicator is Test instead of Dev.](deployment-to-a-hosting-provider-deploying-to-iis-as-a-test-environment-5-of-12/_static/image20.png)](deployment-to-a-hosting-provider-deploying-to-iis-as-a-test-environment-5-of-12/_static/image19.png)
 
 Run the **Students** page to verify that the deployed database has no students. When you select this page it may take a few minutes to load because Code First creates the database and then runs the `Seed` method. (It didn't do that when you were on the home page because the application didn't try to access the database yet.)
 

--- a/aspnet/web-forms/overview/older-versions-getting-started/getting-started-with-ef/the-entity-framework-and-aspnet-getting-started-part-1.md
+++ b/aspnet/web-forms/overview/older-versions-getting-started/getting-started-with-ef/the-entity-framework-and-aspnet-getting-started-part-1.md
@@ -42,7 +42,7 @@ by [Tom Dykstra](https://github.com/tdykstra)
 
 The application you'll be building in these tutorials is a simple university website.
 
-[![Image03](the-entity-framework-and-aspnet-getting-started-part-1/_static/image2.png)](the-entity-framework-and-aspnet-getting-started-part-1/_static/image1.png)
+[![Screenshot of the Contoso University home page, which is showing links to the Home, About, Students, Courses, Instructors, and Departments pages.](the-entity-framework-and-aspnet-getting-started-part-1/_static/image2.png)](the-entity-framework-and-aspnet-getting-started-part-1/_static/image1.png)
 
 Users can view and update student, course, and instructor information. A few of the screens you'll create are shown below.
 
@@ -78,7 +78,7 @@ Open the *Default.aspx* page and change the `Content` control named `BodyContent
 
 You now have a simple home page with links to the various pages that you'll be creating:
 
-[![Image03](the-entity-framework-and-aspnet-getting-started-part-1/_static/image16.png)](the-entity-framework-and-aspnet-getting-started-part-1/_static/image15.png)
+[![Screenshot of the Contoso University home page, which shows links to the Home, About, Students, Courses, Instructors, and Departments pages.](the-entity-framework-and-aspnet-getting-started-part-1/_static/image16.png)](the-entity-framework-and-aspnet-getting-started-part-1/_static/image15.png)
 
 ## Creating the Database
 

--- a/aspnet/web-forms/overview/older-versions-getting-started/getting-started-with-ef/the-entity-framework-and-aspnet-getting-started-part-2.md
+++ b/aspnet/web-forms/overview/older-versions-getting-started/getting-started-with-ef/the-entity-framework-and-aspnet-getting-started-part-2.md
@@ -19,11 +19,11 @@ by [Tom Dykstra](https://github.com/tdykstra)
 
 In the previous tutorial you created a web site, a database, and a data model. In this tutorial you work with the `EntityDataSource` control that ASP.NET provides in order to make it easy to work with an Entity Framework data model. You'll create a `GridView` control for displaying and editing student data, a `DetailsView` control for adding new students, and a `DropDownList` control for selecting a department (which you'll use later for displaying associated courses).
 
-[![Image20](the-entity-framework-and-aspnet-getting-started-part-2/_static/image2.png)](the-entity-framework-and-aspnet-getting-started-part-2/_static/image1.png)
+[![Screenshot of the Internet Explorer window, which is showing the Student List view with a list of students' names, enrollment dates, and courses.](the-entity-framework-and-aspnet-getting-started-part-2/_static/image2.png)](the-entity-framework-and-aspnet-getting-started-part-2/_static/image1.png)
 
-[![Image09](the-entity-framework-and-aspnet-getting-started-part-2/_static/image4.png)](the-entity-framework-and-aspnet-getting-started-part-2/_static/image3.png)
+[![Screenshot of the Internet Explorer window, showing the Add New Students view with John Smith's name and enrollment date filled into the text fields.](the-entity-framework-and-aspnet-getting-started-part-2/_static/image4.png)](the-entity-framework-and-aspnet-getting-started-part-2/_static/image3.png)
 
-[![Image18](the-entity-framework-and-aspnet-getting-started-part-2/_static/image6.png)](the-entity-framework-and-aspnet-getting-started-part-2/_static/image5.png)
+[![Screenshot of the Internet Explorer window, which is showing the Courses by Department view with a dropdown menu for departments.](the-entity-framework-and-aspnet-getting-started-part-2/_static/image6.png)](the-entity-framework-and-aspnet-getting-started-part-2/_static/image5.png)
 
 Note that in this application you won't be adding input validation to pages that update the database, and some of the error handling will not be as robust as would be required in a production application. That keeps the tutorial focused on the Entity Framework and keeps it from getting too long. For details about how to add these features to your application, see [Validating User Input in ASP.NET Web Pages](https://msdn.microsoft.com/library/7kh55542.aspx) and [Error Handling in ASP.NET Pages and Applications](https://msdn.microsoft.com/library/w16865z6.aspx).
 
@@ -187,7 +187,7 @@ In the `Eval` expression, you can reference the navigation property `StudentGrad
 
 Run the page and you now see how many courses each student is enrolled in.
 
-[![Image20](the-entity-framework-and-aspnet-getting-started-part-2/_static/image42.png)](the-entity-framework-and-aspnet-getting-started-part-2/_static/image41.png)
+[![Screenshot of the Internet Explorer window, showing the Add New Students view with John Smith's name and enrollment date filled into the text fields.](the-entity-framework-and-aspnet-getting-started-part-2/_static/image42.png)](the-entity-framework-and-aspnet-getting-started-part-2/_static/image41.png)
 
 ## Using a DetailsView Control to Insert Entities
 
@@ -201,7 +201,7 @@ This markup creates an `EntityDataSource` control that is similar to the one you
 
 Run the page and add a new student.
 
-[![Image09](the-entity-framework-and-aspnet-getting-started-part-2/_static/image44.png)](the-entity-framework-and-aspnet-getting-started-part-2/_static/image43.png)
+[![Screenshot of the Internet Explorer window, showing the Add New Students view with John Smith's name and enrollment date filled into the text fields.](the-entity-framework-and-aspnet-getting-started-part-2/_static/image44.png)](the-entity-framework-and-aspnet-getting-started-part-2/_static/image43.png)
 
 Nothing will happen after you insert a new student, but if you now run *Students.aspx*, you'll see the new student information.
 
@@ -235,7 +235,7 @@ As a reminder, change the markup for the `EntityDataSource` control at this poin
 
 Run the page and you can select a department from the drop-down list.
 
-[![Image18](the-entity-framework-and-aspnet-getting-started-part-2/_static/image52.png)](the-entity-framework-and-aspnet-getting-started-part-2/_static/image51.png)
+[![Screenshot of the Internet Explorer browser window, which shows the Courses by Department view with a dropdown menu for departments.](the-entity-framework-and-aspnet-getting-started-part-2/_static/image52.png)](the-entity-framework-and-aspnet-getting-started-part-2/_static/image51.png)
 
 This completes the introduction to using the `EntityDataSource` control. Working with this control is generally no different from working with other ASP.NET data source controls, except that you reference entities and properties instead of tables and columns. The only exception is when you want to access navigation properties. In the next tutorial you'll see that the syntax you use with `EntityDataSource` control might also differ from other data source controls when you filter, group, and order data.
 

--- a/aspnet/web-forms/overview/older-versions-getting-started/getting-started-with-ef/the-entity-framework-and-aspnet-getting-started-part-3.md
+++ b/aspnet/web-forms/overview/older-versions-getting-started/getting-started-with-ef/the-entity-framework-and-aspnet-getting-started-part-3.md
@@ -21,13 +21,13 @@ In the previous tutorial you used the `EntityDataSource` control to display and 
 
 You'll change the *Students.aspx* page to filter for students, sort by name, and search on name. You'll also change the *Courses.aspx* page to display courses for the selected department and search for courses by name. Finally, you'll add student statistics to the *About.aspx* page.
 
-[![Image02](the-entity-framework-and-aspnet-getting-started-part-3/_static/image2.png)](the-entity-framework-and-aspnet-getting-started-part-3/_static/image1.png)
+[![Screenshot of the Internet Explorer window, which is showing the Student List view with a table of students.](the-entity-framework-and-aspnet-getting-started-part-3/_static/image2.png)](the-entity-framework-and-aspnet-getting-started-part-3/_static/image1.png)
 
-[![Image11](the-entity-framework-and-aspnet-getting-started-part-3/_static/image4.png)](the-entity-framework-and-aspnet-getting-started-part-3/_static/image3.png)
+[![Screenshot of the Internet Explorer window, which is showing the Courses by Department and Courses by Name views.](the-entity-framework-and-aspnet-getting-started-part-3/_static/image4.png)](the-entity-framework-and-aspnet-getting-started-part-3/_static/image3.png)
 
-[![Image10](the-entity-framework-and-aspnet-getting-started-part-3/_static/image6.png)](the-entity-framework-and-aspnet-getting-started-part-3/_static/image5.png)
+[![Screenshot of the Internet Explorer window, which is showing the Student Body Statistics view with a table of enrollment dates.](the-entity-framework-and-aspnet-getting-started-part-3/_static/image6.png)](the-entity-framework-and-aspnet-getting-started-part-3/_static/image5.png)
 
-[![Image14](the-entity-framework-and-aspnet-getting-started-part-3/_static/image8.png)](the-entity-framework-and-aspnet-getting-started-part-3/_static/image7.png)
+[![Screenshot of the Internet Explorer window, which is showing the Find Students by Name view with the letter g entered into the search query.](the-entity-framework-and-aspnet-getting-started-part-3/_static/image8.png)](the-entity-framework-and-aspnet-getting-started-part-3/_static/image7.png)
 
 ## Using the EntityDataSource "Where" Property to Filter Data
 
@@ -41,7 +41,7 @@ The syntax you use in the `Where` property of the `EntityDataSource` control is 
 
 Run the page. The students list now contains only students. (There are no rows displayed where there's no enrollment date.)
 
-[![Image02](the-entity-framework-and-aspnet-getting-started-part-3/_static/image12.png)](the-entity-framework-and-aspnet-getting-started-part-3/_static/image11.png)
+[![Screenshot of the Internet Explorer window, which shows the Student List view with a table of students.](the-entity-framework-and-aspnet-getting-started-part-3/_static/image12.png)](the-entity-framework-and-aspnet-getting-started-part-3/_static/image11.png)
 
 ## Using the EntityDataSource "OrderBy" Property to Order Data
 
@@ -116,7 +116,7 @@ Add the following markup to create a `GridView` control to display the data.
 
 Run the page to see a list showing the number of students by enrollment date.
 
-[![Image10](the-entity-framework-and-aspnet-getting-started-part-3/_static/image28.png)](the-entity-framework-and-aspnet-getting-started-part-3/_static/image27.png)
+[![Screenshot of the Internet Explorer window, which shows the Student Body Statistics view with a table of enrollment dates.](the-entity-framework-and-aspnet-getting-started-part-3/_static/image28.png)](the-entity-framework-and-aspnet-getting-started-part-3/_static/image27.png)
 
 ## Using the QueryExtender Control for Filtering and Ordering
 
@@ -148,7 +148,7 @@ The first column is a template field that displays the department name. The data
 
 Run the page. The initial display shows a list of all courses in order by department and then by course title.
 
-[![Image11](the-entity-framework-and-aspnet-getting-started-part-3/_static/image30.png)](the-entity-framework-and-aspnet-getting-started-part-3/_static/image29.png)
+[![Screenshot of the Internet Explorer window, which shows the Courses by Department and Courses by Name views.](the-entity-framework-and-aspnet-getting-started-part-3/_static/image30.png)](the-entity-framework-and-aspnet-getting-started-part-3/_static/image29.png)
 
 Enter an "m" and click **Search** to see all courses whose titles begin with "m" (the search is not case sensitive).
 
@@ -170,7 +170,7 @@ Run the page. Initially you see all of the students because the default value fo
 
 Enter the letter "g" in the text box and click **Search**. You see a list of students that have a "g" in either the first or last name.
 
-[![Image14](the-entity-framework-and-aspnet-getting-started-part-3/_static/image36.png)](the-entity-framework-and-aspnet-getting-started-part-3/_static/image35.png)
+[![Screenshot of the Internet Explorer window, which shows the Find Students by Name view with the letter g entered into the search query.](the-entity-framework-and-aspnet-getting-started-part-3/_static/image36.png)](the-entity-framework-and-aspnet-getting-started-part-3/_static/image35.png)
 
 You've now displayed, updated, filtered, ordered, and grouped data from individual tables. In the next tutorial you'll begin to work with related data (master-detail scenarios).
 

--- a/aspnet/web-forms/overview/older-versions-getting-started/getting-started-with-ef/the-entity-framework-and-aspnet-getting-started-part-5.md
+++ b/aspnet/web-forms/overview/older-versions-getting-started/getting-started-with-ef/the-entity-framework-and-aspnet-getting-started-part-5.md
@@ -21,11 +21,11 @@ In the previous tutorial you began to use the `EntityDataSource` control to work
 
 You'll create a page that adds courses that are assigned to departments. The departments already exist, and when you create a new course, at the same time you'll establish a relationship between it and an existing department.
 
-[![Image02](the-entity-framework-and-aspnet-getting-started-part-5/_static/image2.png)](the-entity-framework-and-aspnet-getting-started-part-5/_static/image1.png)
+[![Screenshot of the Internet Explorer window, which is showing the Add Courses view with ID, Title, and Credits text fields and a Department dropdown.](the-entity-framework-and-aspnet-getting-started-part-5/_static/image2.png)](the-entity-framework-and-aspnet-getting-started-part-5/_static/image1.png)
 
 You'll also create a page that works with a many-to-many relationship by assigning an instructor to a course (adding a relationship between two entities that you select) or removing an instructor from a course (removing a relationship between two entities that you select). In the database, adding a relationship between an instructor and a course results in a new row being added to the `CourseInstructor` association table; removing a relationship involves deleting a row from the `CourseInstructor` association table. However, you do this in the Entity Framework by setting navigation properties, without referring to the `CourseInstructor` table explicitly.
 
-[![Image01](the-entity-framework-and-aspnet-getting-started-part-5/_static/image4.png)](the-entity-framework-and-aspnet-getting-started-part-5/_static/image3.png)
+[![Screenshot of the Internet Explorer window, which is showing the Assign Instructors to Courses or Remove from Courses view.](the-entity-framework-and-aspnet-getting-started-part-5/_static/image4.png)](the-entity-framework-and-aspnet-getting-started-part-5/_static/image3.png)
 
 ## Adding an Entity with a Relationship to an Existing Entity
 
@@ -57,7 +57,7 @@ The Entity Framework will take care of adding this course to the `Courses` navig
 
 Run the page.
 
-[![Image02](the-entity-framework-and-aspnet-getting-started-part-5/_static/image6.png)](the-entity-framework-and-aspnet-getting-started-part-5/_static/image5.png)
+[![Screenshot of the Internet Explorer window, which shows the Add Courses view with ID, Title, and Credits text fields and a Department dropdown.](the-entity-framework-and-aspnet-getting-started-part-5/_static/image6.png)](the-entity-framework-and-aspnet-getting-started-part-5/_static/image5.png)
 
 Enter an ID, a title, a number of credits, and select a department, then click **Insert**.
 
@@ -111,7 +111,7 @@ Add code to the `Page_Load` method that makes sure the error messages are not vi
 
 Run the page.
 
-[![Image01](the-entity-framework-and-aspnet-getting-started-part-5/_static/image10.png)](the-entity-framework-and-aspnet-getting-started-part-5/_static/image9.png)
+[![Screenshot of the Internet Explorer window, which shows the Assign Instructors to Courses or Remove from Courses view with corresponding dropdowns.](the-entity-framework-and-aspnet-getting-started-part-5/_static/image10.png)](the-entity-framework-and-aspnet-getting-started-part-5/_static/image9.png)
 
 Select an instructor. The <strong>Assign a Course</strong> drop-down list displays the courses that the instructor doesn't teach, and the <strong>Remove a Course</strong> drop-down list displays the courses that the instructor is already assigned to. In the <strong>Assign a Course</strong> section, select a course and then click <strong>Assign</strong>. The course moves to the <strong>Remove a Course</strong> drop-down list. Select a course in the <strong>Remove a Course</strong> section and click <strong>Remove</strong><em>.</em> The course moves to the <strong>Assign a Course</strong> drop-down list.
 


### PR DESCRIPTION
Fixed: 

- image-alt-text-duplicated errors (duplicate alt text descriptions within an article)

This PR fixes 36 issues across 10 files and is part of ongoing Validation cleanup efforts. No other content has been edited or added.