### PR TITLE
Validation: Missing descriptions, disallowed HTML tags, absolute links, duplicate h1s, duplicate titles, and hard-coded-locale fixes.

### DIFF
--- a/aspnet/identity/index.md
+++ b/aspnet/identity/index.md
@@ -2,7 +2,7 @@
 uid: identity/index
 title: "ASP.NET Identity | Microsoft Docs"
 author: rick-anderson
-description: ""
+description: This index topic provides a list of topics related to ASP.NET Identity, a cross-platform modern membership system.
 ms.author: riande
 ms.date: 10/02/2013
 ms.assetid: 0c2df5d4-c2dd-486d-b0ed-fe831c6b596c

--- a/aspnet/identity/overview/index.md
+++ b/aspnet/identity/overview/index.md
@@ -2,7 +2,7 @@
 uid: identity/overview/index
 title: "ASP.NET Identity Overview - ASP.NET 4.x"
 author: rick-anderson
-description: ""
+description: This overview topic provides a list of topics related to ASP.NET Identity, a cross-platform modern membership system.
 ms.author: riande
 ms.date: 10/02/2013
 ms.assetid: d3972a0e-9ff6-4de1-bf4d-c94943cab048

--- a/aspnet/mvc/mvc4.md
+++ b/aspnet/mvc/mvc4.md
@@ -1,6 +1,6 @@
 ---
 uid: mvc/mvc4
-title: "ASP.NET MVC 4 | Microsoft Docs"
+title: "ASP.NET MVC 4 Overview | Microsoft Docs"
 author: rick-anderson
 description: "ASP.NET MVC 4 ASP.NET MVC 4 is a framework for building scalable, standards-based web applications using well-established design patterns and the power of AS..."
 ms.author: riande
@@ -9,7 +9,7 @@ ms.assetid: 1279f5b1-390f-4b4b-9e6e-f947cb1ef5f5
 msc.legacyurl: /mvc/mvc4
 msc.type: content
 ---
-# ASP.NET MVC 4
+# ASP.NET MVC 4 Overview
 
 ### Top Features
 

--- a/aspnet/mvc/overview/index.md
+++ b/aspnet/mvc/overview/index.md
@@ -2,7 +2,7 @@
 uid: mvc/overview/index
 title: "ASP.NET MVC Guidance | Microsoft Docs"
 author: rick-anderson
-description: ""
+description: This index topic provides a list of topics related to ASP.NET MVC that cover layout and themes, security, deployment, performance, and more.
 ms.author: riande
 ms.date: 06/23/2011
 ms.assetid: 946574c5-b5cb-423b-a6e1-a2cfb506ecf9

--- a/aspnet/mvc/overview/older-versions/working-with-the-dropdownlist-box-and-jquery/adding-a-new-category-to-the-dropdownlist-using-jquery-ui.md
+++ b/aspnet/mvc/overview/older-versions/working-with-the-dropdownlist-box-and-jquery/adding-a-new-category-to-the-dropdownlist-using-jquery-ui.md
@@ -2,7 +2,7 @@
 uid: mvc/overview/older-versions/working-with-the-dropdownlist-box-and-jquery/adding-a-new-category-to-the-dropdownlist-using-jquery-ui
 title: "Adding a New Category to the DropDownList using jQuery UI | Microsoft Docs"
 author: Rick-Anderson
-description: ""
+description: This third part of a tutorial series describes how to add a new category to the DropDownList object using jQuery UI.
 ms.author: riande
 ms.date: 01/12/2012
 ms.assetid: 44aa1ac4-6ea2-48a2-972d-52710c48eae5

--- a/aspnet/mvc/overview/older-versions/working-with-the-dropdownlist-box-and-jquery/examining-how-aspnet-mvc-scaffolds-the-dropdownlist-helper.md
+++ b/aspnet/mvc/overview/older-versions/working-with-the-dropdownlist-box-and-jquery/examining-how-aspnet-mvc-scaffolds-the-dropdownlist-helper.md
@@ -2,7 +2,7 @@
 uid: mvc/overview/older-versions/working-with-the-dropdownlist-box-and-jquery/examining-how-aspnet-mvc-scaffolds-the-dropdownlist-helper
 title: "Examining  how  ASP.NET MVC scaffolds the DropDownList Helper | Microsoft Docs"
 author: Rick-Anderson
-description: ""
+description: This second part of a tutorial series describes how ASP.NET MVC scaffolds the DropDownList Helper object.
 ms.author: riande
 ms.date: 01/12/2012
 ms.assetid: 8921d7f2-21f0-427a-8b27-2df7251174b0

--- a/aspnet/mvc/overview/older-versions/working-with-the-dropdownlist-box-and-jquery/using-the-dropdownlist-helper-with-aspnet-mvc.md
+++ b/aspnet/mvc/overview/older-versions/working-with-the-dropdownlist-box-and-jquery/using-the-dropdownlist-helper-with-aspnet-mvc.md
@@ -2,7 +2,7 @@
 uid: mvc/overview/older-versions/working-with-the-dropdownlist-box-and-jquery/using-the-dropdownlist-helper-with-aspnet-mvc
 title: "Using the DropDownList Helper with ASP.NET MVC | Microsoft Docs"
 author: Rick-Anderson
-description: ""
+description: This first part of a tutorial series shows how to use the DropDownList helper an the ListBox helper in an ASP.NET MVC Web application.
 ms.author: riande
 ms.date: 01/12/2012
 ms.assetid: 53767e05-c8ab-42e1-a94b-22d906195200

--- a/aspnet/mvc/overview/views/dynamic-v-strongly-typed-views.md
+++ b/aspnet/mvc/overview/views/dynamic-v-strongly-typed-views.md
@@ -2,7 +2,7 @@
 uid: mvc/overview/views/dynamic-v-strongly-typed-views
 title: "Dynamic v. Strongly Typed Views | Microsoft Docs"
 author: Rick-Anderson
-description: ""
+description: This topic provides an example application that compares and contrasts dynamic views and strongly typed views using a list of blogs.
 ms.author: riande
 ms.date: 01/27/2011
 ms.assetid: 0cbd88da-0da6-4605-b222-2835c6478304

--- a/aspnet/mvc/videos/mvc-4/index.md
+++ b/aspnet/mvc/videos/mvc-4/index.md
@@ -1,6 +1,6 @@
 ---
 uid: mvc/videos/mvc-4/index
-title: "ASP.NET MVC 4 | Microsoft Docs"
+title: "ASP.NET MVC 4 Index | Microsoft Docs"
 author: rick-anderson
 description: "ASP.NET MVC 4"
 ms.author: riande
@@ -9,7 +9,7 @@ ms.assetid: 8130a6c9-2f54-48ba-90f6-0ba52e98f0af
 msc.legacyurl: /mvc/videos/mvc-4
 msc.type: chapter
 ---
-# ASP.NET MVC 4
+# ASP.NET MVC 4 Index
 
 > ASP.NET MVC 4
 

--- a/aspnet/signalr/overview/index.md
+++ b/aspnet/signalr/overview/index.md
@@ -2,7 +2,7 @@
 uid: signalr/overview/index
 title: "SignalR Guidance | Microsoft Docs"
 author: bradygaster
-description: ""
+description: This index topic provides a list of links to topics and tutorials related to the ASP.NET SignalR library.
 ms.author: bradyg
 ms.date: 10/24/2012
 ms.assetid: e57da75a-1d98-4e3c-8787-f1d7e1eb2d86

--- a/aspnet/visual-studio/index.md
+++ b/aspnet/visual-studio/index.md
@@ -2,7 +2,7 @@
 uid: visual-studio/index
 title: "Visual Studio 2012 and 2013 with ASP.NET | Microsoft Docs"
 author: rick-anderson
-description: ""
+description: This index topic provides a list of links that describe how to use older versions of Visual Studio with ASP.NET.
 ms.author: riande
 ms.date: 06/25/2013
 ms.assetid: 7356f644-2b54-4d9f-8863-9d59b9f75532

--- a/aspnet/visual-studio/overview/2012/visual-studio-2012-css-editor.md
+++ b/aspnet/visual-studio/overview/2012/visual-studio-2012-css-editor.md
@@ -2,7 +2,7 @@
 uid: visual-studio/overview/2012/visual-studio-2012-css-editor
 title: "Visual Studio 2012 CSS Editor | Microsoft Docs"
 author: shanselman
-description: ""
+description: This topic provides a 4 minute video that shows the features inside of the Visual Studio 2012 CSS Editor.
 ms.author: riande
 ms.date: 08/15/2012
 ms.assetid: aba1e91b-57cf-4c02-9ab1-5374310be497

--- a/aspnet/visual-studio/overview/2012/visual-studio-2012-javascript-editor.md
+++ b/aspnet/visual-studio/overview/2012/visual-studio-2012-javascript-editor.md
@@ -2,7 +2,7 @@
 uid: visual-studio/overview/2012/visual-studio-2012-javascript-editor
 title: "Visual Studio 2012 JavaScript Editor | Microsoft Docs"
 author: shanselman
-description: ""
+description: This topic provides a 5 minute video that shows the improvements made to the Visual Studio 2012 Javascript Editor.
 ms.author: riande
 ms.date: 08/15/2012
 ms.assetid: b7c029cf-3fe0-4528-beb4-f577514b48ef

--- a/aspnet/web-api/overview/releases/whats-new-in-aspnet-web-api-21.md
+++ b/aspnet/web-api/overview/releases/whats-new-in-aspnet-web-api-21.md
@@ -2,7 +2,7 @@
 uid: web-api/overview/releases/whats-new-in-aspnet-web-api-21
 title: "What's New in ASP.NET Web API 2.1 | Microsoft Docs"
 author: rick-anderson
-description: ""
+description: This topic describes the new features and bug fixes introduced in ASP.NET Web API 2.1 and provides links to downloads and documentation.
 ms.author: riande
 ms.date: 01/20/2014
 ms.assetid: b6721bba-38c8-48c4-acbf-274c1a34e817

--- a/aspnet/web-api/overview/releases/whats-new-in-aspnet-web-api-odata-53.md
+++ b/aspnet/web-api/overview/releases/whats-new-in-aspnet-web-api-odata-53.md
@@ -2,7 +2,7 @@
 uid: web-api/overview/releases/whats-new-in-aspnet-web-api-odata-53
 title: "What's New in ASP.NET Web API OData 5.3 | Microsoft Docs"
 author: rick-anderson
-description: ""
+description: This topic describes the new features and bug fixes introduced in ASP.NET Web API OData 5.3 and provides links to downloads and documentation.
 ms.author: riande
 ms.date: 09/16/2014
 ms.assetid: e39eaa25-83ff-41dc-869d-3818d59a88ae

--- a/aspnet/web-api/overview/web-api-routing-and-actions/attribute-routing-in-web-api-2.md
+++ b/aspnet/web-api/overview/web-api-routing-and-actions/attribute-routing-in-web-api-2.md
@@ -2,7 +2,7 @@
 uid: web-api/overview/web-api-routing-and-actions/attribute-routing-in-web-api-2
 title: "Attribute Routing in ASP.NET Web API 2 | Microsoft Docs"
 author: MikeWasson
-description: ""
+description: This topic discusses how to enable attribute routing in ASP.NET Web API 2 and describes various options for attribute routing.
 ms.author: riande
 ms.date: 01/20/2014
 ms.assetid: 979d6c9f-0129-4e5b-ae56-4507b281b86d

--- a/aspnet/web-api/videos/index.md
+++ b/aspnet/web-api/videos/index.md
@@ -2,7 +2,7 @@
 uid: web-api/videos/index
 title: "ASP.NET Web API Videos | Microsoft Docs"
 author: rick-anderson
-description: ""
+description: This topic provides a list of links to a walkthrough series regarding usage of the ASP.NET Web API and development using the API.
 ms.author: riande
 ms.date: 02/16/2012
 ms.assetid: 8ed7e133-707b-43e6-bce4-e9d266935573

--- a/aspnet/web-forms/overview/getting-started/code-editing-in-web-forms-pages.md
+++ b/aspnet/web-forms/overview/getting-started/code-editing-in-web-forms-pages.md
@@ -2,7 +2,7 @@
 uid: web-forms/overview/getting-started/code-editing-in-web-forms-pages
 title: "Code Editing ASP.NET Web Forms in Visual Studio 2013 | Microsoft Docs"
 author: Erikre
-description: ""
+description: This walkthrough shows how to use various features of the Visual Studio Code Editor to write code quickly while avoiding errors.
 ms.author: riande
 ms.date: 03/03/2014
 ms.assetid: 5344b74e-b888-479a-92bc-601a33bd61a2

--- a/aspnet/web-forms/overview/getting-started/creating-a-basic-web-forms-page.md
+++ b/aspnet/web-forms/overview/getting-started/creating-a-basic-web-forms-page.md
@@ -2,7 +2,7 @@
 uid: web-forms/overview/getting-started/creating-a-basic-web-forms-page
 title: Using Visual Studio 2013 to create a Basic ASP.NET 4.5 Web Forms Page
 author: Erikre
-description: ""
+description: This walkthrough describes how to use Visual Studio 2013 to create a basic ASP.NET 4.5 Web Forms page.
 ms.author: riande
 ms.date: 03/03/2014
 ms.assetid: a2f1c635-0817-4a9a-8c13-d5b5d29727c0

--- a/aspnet/web-forms/overview/index.md
+++ b/aspnet/web-forms/overview/index.md
@@ -2,7 +2,7 @@
 uid: web-forms/overview/index
 title: "ASP.NET Web Forms Guidance | Microsoft Docs"
 author: rick-anderson
-description: ""
+description: This topic provides links to articles and resources about ASP.NET Web Forms and using it for development.
 ms.author: riande
 ms.date: 08/08/2011
 ms.assetid: b3fb4480-0f41-495b-add6-163ca92dc8a3

--- a/aspnet/web-forms/overview/older-versions-getting-started/deploying-web-site-projects/configuring-a-website-that-uses-application-services-vb.md
+++ b/aspnet/web-forms/overview/older-versions-getting-started/deploying-web-site-projects/configuring-a-website-that-uses-application-services-vb.md
@@ -166,7 +166,7 @@ For more information on the topics discussed in this tutorial, refer to the foll
 - [*ASP.NET SQL Server Registration Tool (aspnet_regsql.exe)*](https://msdn.microsoft.com/library/ms229862.aspx)
 - [*Creating the Application Services Database for SQL Server*](https://msdn.microsoft.com/library/x28wfk74.aspx)
 - [*Creating the Membership Schema in SQL Server*](../../older-versions-security/membership/creating-the-membership-schema-in-sql-server-vb.md)
-- [*Examining ASP.NET s Membership, Roles, and Profile*](https://docs.microsoft.com/en-us/previous-versions/aspnet/yh26yfzy(v=vs.100))
+- [*Examining ASP.NET s Membership, Roles, and Profile*](/previous-versions/aspnet/yh26yfzy(v=vs.100))
 - *Rolling Your Own Web Site Administration Tool*
 - [*Website Security Tutorials*](../../older-versions-security/introduction/security-basics-and-asp-net-support-cs.md)
 - [*Web Site Administration Tool Overview*](https://msdn.microsoft.com/library/yy40ytx0.aspx)

--- a/aspnet/web-forms/overview/older-versions-getting-started/deploying-web-site-projects/processing-unhandled-exceptions-cs.md
+++ b/aspnet/web-forms/overview/older-versions-getting-started/deploying-web-site-projects/processing-unhandled-exceptions-cs.md
@@ -143,7 +143,7 @@ Happy Programming!
 For more information on the topics discussed in this tutorial, refer to the following resources:
 
 - [ASP.NET HTTP Modules and HTTP Handlers Overview](https://support.microsoft.com/kb/307985)
-- [Gracefully Responding to Unhandled Exceptions - Processing Unhandled Exceptions](https://docs.microsoft.com/en-us/aspnet/web-forms/overview/older-versions-getting-started/deploying-web-site-projects/processing-unhandled-exceptions-cs)
+- [Gracefully Responding to Unhandled Exceptions - Processing Unhandled Exceptions](/aspnet/web-forms/overview/older-versions-getting-started/deploying-web-site-projects/processing-unhandled-exceptions-cs)
 - [`HttpApplication` Class and the ASP.NET Application Object](http://www.eggheadcafe.com/articles/20030211.asp)
 - [HTTP Handlers and HTTP Modules in ASP.NET](/previous-versions/aspnet/bb398986(v=vs.100))
 - [Sending Email in ASP.NET](/aspnet/web-pages/overview/getting-started/11-adding-email-to-your-web-site)

--- a/aspnet/web-forms/overview/older-versions-getting-started/deploying-web-site-projects/processing-unhandled-exceptions-vb.md
+++ b/aspnet/web-forms/overview/older-versions-getting-started/deploying-web-site-projects/processing-unhandled-exceptions-vb.md
@@ -144,7 +144,7 @@ Happy Programming!
 For more information on the topics discussed in this tutorial, refer to the following resources:
 
 - [ASP.NET HTTP Modules and HTTP Handlers Overview](https://support.microsoft.com/kb/307985)
-- [Gracefully Responding to Unhandled Exceptions - Processing Unhandled Exceptions](https://docs.microsoft.com/en-us/aspnet/web-forms/overview/older-versions-getting-started/deploying-web-site-projects/processing-unhandled-exceptions-cs)
+- [Gracefully Responding to Unhandled Exceptions - Processing Unhandled Exceptions](/aspnet/web-forms/overview/older-versions-getting-started/deploying-web-site-projects/processing-unhandled-exceptions-cs)
 - [`HttpApplication` Class and the ASP.NET Application Object](http://www.eggheadcafe.com/articles/20030211.asp)
 - [HTTP Handlers and HTTP Modules in ASP.NET](/previous-versions/aspnet/bb398986(v=vs.100))
 - [Sending Email in ASP.NET](/aspnet/web-pages/overview/getting-started/11-adding-email-to-your-web-site)

--- a/aspnet/web-forms/overview/older-versions-getting-started/getting-started-with-ef/the-entity-framework-and-aspnet-getting-started-part-8.md
+++ b/aspnet/web-forms/overview/older-versions-getting-started/getting-started-with-ef/the-entity-framework-and-aspnet-getting-started-part-8.md
@@ -114,7 +114,7 @@ Now that you've set up these formatting and validation rules in the data model m
 This concludes this series of tutorials on Getting Started with the Entity Framework. For more resources to help you learn how to use the Entity Framework, continue with [the first tutorial in the next Entity Framework tutorial series](../continuing-with-ef/using-the-entity-framework-and-the-objectdatasource-control-part-1-getting-started.md) or visit the following sites:
 
 
-- [The Entity Framework Team Blog](https://docs.microsoft.com/archive/blogs/adonet/)
+- [The Entity Framework Team Blog](/archive/blogs/adonet/)
 - [Entity Framework in the MSDN Library](https://msdn.microsoft.com/library/bb399572.aspx)
 - [Entity Framework in the MSDN Data Developer Center](https://msdn.microsoft.com/data/ef.aspx)
 - [EntityDataSource Web Server Control Overview in the MSDN Library](https://msdn.microsoft.com/library/cc488502.aspx)

--- a/aspnet/web-forms/what-is-web-forms.md
+++ b/aspnet/web-forms/what-is-web-forms.md
@@ -2,7 +2,7 @@
 uid: web-forms/what-is-web-forms
 title: "What is Web Forms | Microsoft Docs"
 author: rick-anderson
-description: ""
+description: This topic provides an overview of ASP.NET Web forms, which is one of the four programming models that can be used to create ASP.NET web applications.
 ms.author: riande
 ms.date: 02/21/2014
 ms.assetid: 5fa1daf9-1161-4cfa-bd4c-658f48b2c229

--- a/aspnet/web-pages/content-guide.md
+++ b/aspnet/web-pages/content-guide.md
@@ -1,6 +1,7 @@
 ---
 uid: web-pages/content-guide
 title: "WebMatrix Content Guide | Microsoft Docs"
+description: This topic provides a list of links to articles, videos, and resources that discuss development scenarios for WebMatrix content.
 author: rick-anderson
 description: ""
 ms.author: riande

--- a/aspnet/web-pages/overview/releases/aspnet-web-pages-2-developer-preview-readme.md
+++ b/aspnet/web-pages/overview/releases/aspnet-web-pages-2-developer-preview-readme.md
@@ -1,6 +1,7 @@
 ---
 uid: web-pages/overview/releases/aspnet-web-pages-2-developer-preview-readme
 title: "ASP.NET Web Pages 2 Developer Preview ReadMe | Microsoft Docs"
+description: This ReadMe provides installation notes and descriptions of fixes, known issues, and changes for the developer preview release of ASP.Net Web Pages 2.
 author: rick-anderson
 description: ""
 ms.author: riande

--- a/aspnet/web-pages/overview/releases/whats-new-aspnet-web-pages-31.md
+++ b/aspnet/web-pages/overview/releases/whats-new-aspnet-web-pages-31.md
@@ -1,6 +1,7 @@
 ---
 uid: web-pages/overview/releases/whats-new-aspnet-web-pages-31
 title: "What's New in ASP.NET Web Pages 3.1 | Microsoft Docs"
+description: This topic describes the 3.1 release of ASP.NET Web Pages, which fixes bugs and does not introduce any new features.
 author: rick-anderson
 description: ""
 ms.author: riande

--- a/aspnet/web-pages/videos/introduction/5-minute-introduction-to-aspnet-web-pages.md
+++ b/aspnet/web-pages/videos/introduction/5-minute-introduction-to-aspnet-web-pages.md
@@ -1,6 +1,7 @@
 ---
 uid: web-pages/videos/introduction/5-minute-introduction-to-aspnet-web-pages
 title: "5 Minute Introduction to ASP.NET Web Pages | Microsoft Docs"
+description: This page provides a video that is a 5 minute introduction to ASP.Net web pages and shows how to use a starter site template in WebMatrix to build a site.
 author: rick-anderson
 description: ""
 ms.author: riande

--- a/aspnet/whitepapers/request-validation.md
+++ b/aspnet/whitepapers/request-validation.md
@@ -39,7 +39,7 @@ Running this code results in a simple page that allows you to enter some text in
 
 However, were JavaScript, such as `<script>alert("hello!")</script>` to be entered and submitted we would get an exception:
 
-![If JavaScript, such as <script>alert("hello!")</script>, were entered and submitted, one would get an exception.](request-validation/_static/image3.png)
+![If JavaScript is entered and submitted, one would get an exception.](request-validation/_static/image3.png)
 
 The error message states that a 'potentially dangerous Request.Form value was detected' and provides more details in the description as to exactly what occurred and how to change the behavior. For example:
 
@@ -71,7 +71,7 @@ The code below is modified to turn off request validation:
 
 Now if the following JavaScript was entered into the textbox `<script>alert("hello!")</script>` the result would be:
 
-![Screenshot that shows if the following JavaScript was entered into the textbox: <script>alert("hello!")</script> the result would be a button "Click Me!" and a dialog box that states "hello!" and a button to click "ok."](request-validation/_static/image5.png)
+![Screenshot that shows if the JavaScript was entered into the textbox: the result would be a button "Click Me!" and a dialog box that states "hello!".](request-validation/_static/image5.png)
 
 To prevent this from happening, with request validation turned off, we need to HTML encode the content.
 
@@ -85,4 +85,4 @@ Content can be easily HTML-encoded on the server using the `Server.HtmlEncode(st
 
 Resulting in:
 
-![Screenshot that shows a button "Click Me!" and "You entered: <script>alert("hello!");</script>" in the text box.](request-validation/_static/image7.png)
+![Screenshot that shows a button "Click Me!" and a successful JavaScript entry message in the text box.](request-validation/_static/image7.png)


### PR DESCRIPTION
Fixed: 

- description-missing errors (missing description metadata)
- disallowed-html-tag errors (disallowed HTML tags which pose a security risk)
- docs-link-absolute errors (absolute links replaced with relative links)
- duplicate-h1s errors (duplicate h1s within a docset)
- duplicate-titles errors (duplicate titles within a docset)
- hard-coded-locale errors (removed locale codes for localizability)

This PR fixes 37 issues across 30 files and is part of ongoing Validation cleanup efforts. No other content has been edited or added.