### PR TITLE
Fix duplicate-alt-text and missing description suggestions #9

### DIFF
--- a/aspnet/aspnet/overview/owin-and-katana/katana-samples.md
+++ b/aspnet/aspnet/overview/owin-and-katana/katana-samples.md
@@ -2,7 +2,7 @@
 uid: aspnet/overview/owin-and-katana/katana-samples
 title: "Katana Samples | Microsoft Docs"
 author: rick-anderson
-description: ""
+description: "This article provides a collection of Katana-based sample code."
 ms.author: riande
 ms.date: 01/17/2014
 ms.assetid: bec04f5d-2638-4417-b288-97c58c8d6379

--- a/aspnet/entity-framework.md
+++ b/aspnet/entity-framework.md
@@ -2,7 +2,7 @@
 uid: entity-framework
 title: "Entity Framework | Microsoft Docs"
 author: rick-anderson
-description: ""
+description: "This article provides an overview of the Entity Framework."
 ms.assetid: faa761a9-86b3-4859-b9c0-60d5c5bc5e93
 ms.author: riande
 ms.date: 03/12/2010

--- a/aspnet/web-forms/overview/data-access/editing-inserting-and-deleting-data/an-overview-of-inserting-updating-and-deleting-data-cs.md
+++ b/aspnet/web-forms/overview/data-access/editing-inserting-and-deleting-data/an-overview-of-inserting-updating-and-deleting-data-cs.md
@@ -256,7 +256,7 @@ As we've seen in earlier tutorials, the DetailsView control displays one record 
 
 To demonstrate the data modification capabilities of the GridView, start by adding a DetailsView to the `Basics.aspx` page above the existing GridView and bind it to the existing ObjectDataSource through the DetailsView's smart tag. Next, clear out the DetailsView's `Height` and `Width` properties, and check the Enable Paging option from the smart tag. To enable editing, inserting, and deleting support, simply check the Enable Editing, Enable Inserting, and Enable Deleting checkboxes in the smart tag.
 
-![Configure the DetailsView to Support Editing, Inserting, and Deleting](an-overview-of-inserting-updating-and-deleting-data-cs/_static/image41.png)
+![Screenshot showing the DetailsView Tasks window with the Enable Inserting, Enable Editing, and Enable Deleting checkboxes selected.](an-overview-of-inserting-updating-and-deleting-data-cs/_static/image41.png)
 
 **Figure 17**: Configure the DetailsView to Support Editing, Inserting, and Deleting
 
@@ -266,7 +266,7 @@ As with the GridView, adding editing, inserting, or deleting support adds a Comm
 
 Note that for the DetailsView the CommandField appears at the end of the Columns collection by default. Since the DetailsView's fields are rendered as rows, the CommandField appears as a row with Insert, Edit, and Delete buttons at the bottom of the DetailsView.
 
-[![Configure the DetailsView to Support Editing, Inserting, and Deleting](an-overview-of-inserting-updating-and-deleting-data-cs/_static/image43.png)](an-overview-of-inserting-updating-and-deleting-data-cs/_static/image42.png)
+[![Screenshot of the DetailsView with the CommandField appearing as a bottom row with Insert, Edit, and Delete buttons.](an-overview-of-inserting-updating-and-deleting-data-cs/_static/image43.png)](an-overview-of-inserting-updating-and-deleting-data-cs/_static/image42.png)
 
 **Figure 18**: Configure the DetailsView to Support Editing, Inserting, and Deleting ([Click to view full-size image](an-overview-of-inserting-updating-and-deleting-data-cs/_static/image44.png))
 
@@ -276,13 +276,13 @@ For inserting, the end user is presented with a New button that, when clicked, r
 
 When binding a data source to a DetailsView through the smart tag, Visual Studio sets the `InsertVisible` property to `false` only for auto-increment fields. Read-only fields, like `CategoryName` and `SupplierName`, will be displayed in the "insert mode" user interface unless their `InsertVisible` property is explicitly set to `false`. Take a moment to set these two fields' `InsertVisible` properties to `false`, either through the DetailsView's declarative syntax or through the Edit Fields link in the smart tag. Figure 19 shows setting the `InsertVisible` properties to `false` by clicking on the Edit Fields link.
 
-[![Northwind Traders Now Offers Acme Tea](an-overview-of-inserting-updating-and-deleting-data-cs/_static/image46.png)](an-overview-of-inserting-updating-and-deleting-data-cs/_static/image45.png)
+[![Screenshot showing the Fields window with the InsertVisible property set to False.](an-overview-of-inserting-updating-and-deleting-data-cs/_static/image46.png)](an-overview-of-inserting-updating-and-deleting-data-cs/_static/image45.png)
 
 **Figure 19**: Northwind Traders Now Offers Acme Tea ([Click to view full-size image](an-overview-of-inserting-updating-and-deleting-data-cs/_static/image47.png))
 
 After setting the `InsertVisible` properties, view the `Basics.aspx` page in a browser and click the New button. Figure 20 shows the DetailsView when adding a new beverage, Acme Tea, to our product line.
 
-[![Northwind Traders Now Offers Acme Tea](an-overview-of-inserting-updating-and-deleting-data-cs/_static/image49.png)](an-overview-of-inserting-updating-and-deleting-data-cs/_static/image48.png)
+[![Screenshot showing the DetailsView of the Basics.aspx page in a web browser.](an-overview-of-inserting-updating-and-deleting-data-cs/_static/image49.png)](an-overview-of-inserting-updating-and-deleting-data-cs/_static/image48.png)
 
 **Figure 20**: Northwind Traders Now Offers Acme Tea ([Click to view full-size image](an-overview-of-inserting-updating-and-deleting-data-cs/_static/image50.png))
 

--- a/aspnet/web-forms/overview/data-access/editing-inserting-and-deleting-data/an-overview-of-inserting-updating-and-deleting-data-vb.md
+++ b/aspnet/web-forms/overview/data-access/editing-inserting-and-deleting-data/an-overview-of-inserting-updating-and-deleting-data-vb.md
@@ -256,7 +256,7 @@ As we've seen in earlier tutorials, the DetailsView control displays one record 
 
 To demonstrate the data modification capabilities of the GridView, start by adding a DetailsView to the `Basics.aspx` page above the existing GridView and bind it to the existing ObjectDataSource through the DetailsView's smart tag. Next, clear out the DetailsView's `Height` and `Width` properties, and check the Enable Paging option from the smart tag. To enable editing, inserting, and deleting support, simply check the Enable Editing, Enable Inserting, and Enable Deleting checkboxes in the smart tag.
 
-![Configure the DetailsView to Support Editing, Inserting, and Deleting](an-overview-of-inserting-updating-and-deleting-data-vb/_static/image41.png)
+![Screenshot showing the DetailsView Tasks window with the Enable Inserting, Enable Editing, and Enable Deleting checkboxes selected.](an-overview-of-inserting-updating-and-deleting-data-vb/_static/image41.png)
 
 **Figure 17**: Configure the DetailsView to Support Editing, Inserting, and Deleting
 
@@ -266,7 +266,7 @@ As with the GridView, adding editing, inserting, or deleting support adds a Comm
 
 Note that for the DetailsView the CommandField appears at the end of the Columns collection by default. Since the DetailsView's fields are rendered as rows, the CommandField appears as a row with Insert, Edit, and Delete buttons at the bottom of the DetailsView.
 
-[![Configure the DetailsView to Support Editing, Inserting, and Deleting](an-overview-of-inserting-updating-and-deleting-data-vb/_static/image43.png)](an-overview-of-inserting-updating-and-deleting-data-vb/_static/image42.png)
+[![Screenshot of the DetailsView with the CommandField appearing as a bottom row with Insert, Edit, and Delete buttons.](an-overview-of-inserting-updating-and-deleting-data-vb/_static/image43.png)](an-overview-of-inserting-updating-and-deleting-data-vb/_static/image42.png)
 
 **Figure 18**: Configure the DetailsView to Support Editing, Inserting, and Deleting ([Click to view full-size image](an-overview-of-inserting-updating-and-deleting-data-vb/_static/image44.png))
 
@@ -276,13 +276,13 @@ For inserting, the end user is presented with a New button that, when clicked, r
 
 When binding a data source to a DetailsView through the smart tag, Visual Studio sets the `InsertVisible` property to `False` only for auto-increment fields. Read-only fields, like `CategoryName` and `SupplierName`, will be displayed in the "insert mode" user interface unless their `InsertVisible` property is explicitly set to `False`. Take a moment to set these two fields' `InsertVisible` properties to `False`, either through the DetailsView's declarative syntax or through the Edit Fields link in the smart tag. Figure 19 shows setting the `InsertVisible` properties to `False` by clicking on the Edit Fields link.
 
-[![Northwind Traders Now Offers Acme Tea](an-overview-of-inserting-updating-and-deleting-data-vb/_static/image46.png)](an-overview-of-inserting-updating-and-deleting-data-vb/_static/image45.png)
+[![Screenshot showing the Fields window with the InsertVisible property set to False.](an-overview-of-inserting-updating-and-deleting-data-vb/_static/image46.png)](an-overview-of-inserting-updating-and-deleting-data-vb/_static/image45.png)
 
 **Figure 19**: Northwind Traders Now Offers Acme Tea ([Click to view full-size image](an-overview-of-inserting-updating-and-deleting-data-vb/_static/image47.png))
 
 After setting the `InsertVisible` properties, view the `Basics.aspx` page in a browser and click the New button. Figure 20 shows the DetailsView when adding a new beverage, Acme Tea, to our product line.
 
-[![Northwind Traders Now Offers Acme Tea](an-overview-of-inserting-updating-and-deleting-data-vb/_static/image49.png)](an-overview-of-inserting-updating-and-deleting-data-vb/_static/image48.png)
+[![Screenshot showing the DetailsView of the Basics.aspx page in a web browser.](an-overview-of-inserting-updating-and-deleting-data-vb/_static/image49.png)](an-overview-of-inserting-updating-and-deleting-data-vb/_static/image48.png)
 
 **Figure 20**: Northwind Traders Now Offers Acme Tea ([Click to view full-size image](an-overview-of-inserting-updating-and-deleting-data-vb/_static/image50.png))
 

--- a/aspnet/web-forms/overview/data-access/editing-inserting-and-deleting-data/examining-the-events-associated-with-inserting-updating-and-deleting-cs.md
+++ b/aspnet/web-forms/overview/data-access/editing-inserting-and-deleting-data/examining-the-events-associated-with-inserting-updating-and-deleting-cs.md
@@ -121,7 +121,7 @@ The formatting instructions specified in the `DataFormatString` property can be 
 
 With this change, the value of the `UnitPrice` displayed in the edited row is also formatted as a currency.
 
-[![The Edited Row's UnitPrice Value is Now Formatted as a Currency](examining-the-events-associated-with-inserting-updating-and-deleting-cs/_static/image29.png)](examining-the-events-associated-with-inserting-updating-and-deleting-cs/_static/image28.png)
+[![Screenshot of the GridView showing the edited row's UnitPrice value formatted as a currency.](examining-the-events-associated-with-inserting-updating-and-deleting-cs/_static/image29.png)](examining-the-events-associated-with-inserting-updating-and-deleting-cs/_static/image28.png)
 
 **Figure 10**: The Edited Row's `UnitPrice` Value is Now Formatted as a Currency ([Click to view full-size image](examining-the-events-associated-with-inserting-updating-and-deleting-cs/_static/image30.png))
 
@@ -135,7 +135,7 @@ If the user has supplied a `UnitPrice` value (such as "$19.00"), this value is o
 
 Figure 11 shows both the problem caused by currency symbols in the user-supplied `UnitPrice`, along with how the GridView's `RowUpdating` event handler can be utilized to correctly parse such input.
 
-[![The Edited Row's UnitPrice Value is Now Formatted as a Currency](examining-the-events-associated-with-inserting-updating-and-deleting-cs/_static/image32.png)](examining-the-events-associated-with-inserting-updating-and-deleting-cs/_static/image31.png)
+[![Diagram showing how the ObjectDataSource processes the UnitPrice field and how the RowUpdate event handler of the GridView converts a string to a decimal.](examining-the-events-associated-with-inserting-updating-and-deleting-cs/_static/image32.png)](examining-the-events-associated-with-inserting-updating-and-deleting-cs/_static/image31.png)
 
 **Figure 11**: The Edited Row's `UnitPrice` Value is Now Formatted as a Currency ([Click to view full-size image](examining-the-events-associated-with-inserting-updating-and-deleting-cs/_static/image33.png))
 

--- a/aspnet/web-forms/overview/data-access/editing-inserting-and-deleting-data/examining-the-events-associated-with-inserting-updating-and-deleting-vb.md
+++ b/aspnet/web-forms/overview/data-access/editing-inserting-and-deleting-data/examining-the-events-associated-with-inserting-updating-and-deleting-vb.md
@@ -121,7 +121,7 @@ The formatting instructions specified in the `DataFormatString` property can be 
 
 With this change, the value of the `UnitPrice` displayed in the edited row is also formatted as a currency.
 
-[![The Edited Row's UnitPrice Value is Now Formatted as a Currency](examining-the-events-associated-with-inserting-updating-and-deleting-vb/_static/image29.png)](examining-the-events-associated-with-inserting-updating-and-deleting-vb/_static/image28.png)
+[![Screenshot of the GridView showing the edited row's UnitPrice value formatted as a currency.](examining-the-events-associated-with-inserting-updating-and-deleting-vb/_static/image29.png)](examining-the-events-associated-with-inserting-updating-and-deleting-vb/_static/image28.png)
 
 **Figure 10**: The Edited Row's `UnitPrice` Value is Now Formatted as a Currency ([Click to view full-size image](examining-the-events-associated-with-inserting-updating-and-deleting-vb/_static/image30.png))
 
@@ -135,7 +135,7 @@ If the user has supplied a `UnitPrice` value (such as "$19.00"), this value is o
 
 Figure 11 shows both the problem caused by currency symbols in the user-supplied `UnitPrice`, along with how the GridView's `RowUpdating` event handler can be utilized to correctly parse such input.
 
-[![The Edited Row's UnitPrice Value is Now Formatted as a Currency](examining-the-events-associated-with-inserting-updating-and-deleting-vb/_static/image32.png)](examining-the-events-associated-with-inserting-updating-and-deleting-vb/_static/image31.png)
+[![Diagram showing how the ObjectDataSource processes the UnitPrice field and how the RowUpdate event handler of the GridView converts a string to a decimal.](examining-the-events-associated-with-inserting-updating-and-deleting-vb/_static/image32.png)](examining-the-events-associated-with-inserting-updating-and-deleting-vb/_static/image31.png)
 
 **Figure 11**: The Edited Row's `UnitPrice` Value is Now Formatted as a Currency ([Click to view full-size image](examining-the-events-associated-with-inserting-updating-and-deleting-vb/_static/image33.png))
 


### PR DESCRIPTION
**Global effort to fix validation errors**

The Content & Learning team is fixing build validation errors on docs.microsoft.com. This effort will eliminate potential accessibility, security, and usability issues. This PR includes only build validation fixes and does not change other content. I’d very much appreciate your timely review and feedback on these changes I’ve suggested. Thanks!