### PR TITLE
remove the links doesn`t exist.

### DIFF
--- a/aspnet/web-api/overview/advanced/calling-a-web-api-from-a-net-client.md
+++ b/aspnet/web-api/overview/advanced/calling-a-web-api-from-a-net-client.md
@@ -17,7 +17,7 @@ This content is for a previous version of .NET. New development should use [ASP.
 * [Tutorial: Create a web API with ASP.NET Core](/aspnet/core/tutorials/first-web-api)
 * [Call an HTTP endpoint from a .NET client](/dotnet/csharp/tutorials/console-webapiclient)
 
-[Download Completed Project](https://github.com/dotnet/AspNetDocs/tree/main/aspnet/web-api/overview/advanced/calling-a-web-api-from-a-net-client/sample). [Download instructions](/aspnet/core/tutorials/#how-to-download-a-sample). 
+[Download Completed Project](https://github.com/dotnet/AspNetDocs/tree/main/aspnet/web-api/overview/advanced/calling-a-web-api-from-a-net-client/sample). 
 
 This tutorial shows how to call a web API from a .NET application, using [System.Net.Http.HttpClient.](https://msdn.microsoft.com/library/system.net.http.httpclient(v=vs.110).aspx)
 
@@ -168,7 +168,7 @@ Like GET, a DELETE request does not have a request body. You don't need to speci
 
 To test the client app:
 
-1. [Download](https://github.com/dotnet/AspNetDocs/tree/main/aspnet/web-api/overview/advanced/calling-a-web-api-from-a-net-client/sample/server) and run the server app. [Download instructions](/aspnet/core/#how-to-download-a-sample). Verify the server app is working. For example, `http://localhost:64195/api/products` should return a list of products.
+1. [Download](https://github.com/dotnet/AspNetDocs/tree/main/aspnet/web-api/overview/advanced/calling-a-web-api-from-a-net-client/sample/server) and run the server app. Verify the server app is working. For example, `http://localhost:64195/api/products` should return a list of products.
 2. Set the base URI for HTTP requests. Change the port number to the port used in the server app.
     [!code-csharp[Main](calling-a-web-api-from-a-net-client/sample/client/Program.cs?name=snippet5)]
 


### PR DESCRIPTION
These two "download instructions" links do not exist. I can`t find them in this doc repo. Maybe providing a new guide is better.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->