### PR TITLE
[BULK UPDATE] DocuTune - Rebranding links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contribute to the ASP.NET documentation
 
-This document covers the process for contributing to the articles and code samples that are hosted on the [ASP.NET documentation site](https://docs.microsoft.com/aspnet/). Typo corrections, bug fixes, and new articles are welcome.
+This document covers the process for contributing to the articles and code samples that are hosted on the [ASP.NET documentation site](https://learn.microsoft.com/aspnet/). Typo corrections, bug fixes, and new articles are welcome.
 
 ## How to make a simple correction or suggestion
 
@@ -16,7 +16,7 @@ You need a basic understanding of [Git and GitHub.com](https://guides.github.com
 * If your PR has the label 'cla-required' assigned, [complete the Contribution License Agreement (CLA)](https://cla.dotnetfoundation.org/).
 * Respond to PR feedback.
 
-For an example where this process led to publication of a new article, see [Issue &num;67](https://github.com/dotnet/docs/issues/67) and [Pull Request &num;798](https://github.com/dotnet/docs/pull/798) in the .NET Docs repository. The new article is [Documenting your code](https://docs.microsoft.com/dotnet/articles/csharp/codedoc).
+For an example where this process led to publication of a new article, see [Issue &num;67](https://github.com/dotnet/docs/issues/67) and [Pull Request &num;798](https://github.com/dotnet/docs/pull/798) in the .NET Docs repository. The new article is [Documenting your code](https://learn.microsoft.com/dotnet/articles/csharp/codedoc).
 
 ## Docs Authoring Pack extension in Visual Studio Code
 
@@ -84,7 +84,7 @@ To render a portion of a file as a snippet by using line numbers:
 [!code-html[](configuration/index/sample/Views/Home/Index.cshtml?range=1-10,20,30,40-50]
 ```
 
-For C# snippets, reference a [C# region](https://docs.microsoft.com/dotnet/csharp/language-reference/preprocessor-directives/preprocessor-region). Whenever possible, use regions rather than line numbers because line numbers in a code file tend to change and become out of sync with line number references in Markdown. C# regions can be nested. If referencing the outer region, the inner `#region` and `#endregion` directives aren't rendered in a snippet.
+For C# snippets, reference a [C# region](https://learn.microsoft.com/dotnet/csharp/language-reference/preprocessor-directives/preprocessor-region). Whenever possible, use regions rather than line numbers because line numbers in a code file tend to change and become out of sync with line number references in Markdown. C# regions can be nested. If referencing the outer region, the inner `#region` and `#endregion` directives aren't rendered in a snippet.
 
 To render a C# region named "snippet_Example":
 
@@ -153,7 +153,7 @@ Our goal is to write documentation that is easily understandable by the widest p
 
 ## Microsoft Writing Style Guide
 
-The [Microsoft Writing Style Guide](https://docs.microsoft.com/style-guide/welcome/) provides writing style and terminology guidance for all forms of technology communication, including the ASP.NET Core documentation.
+The [Microsoft Writing Style Guide](https://learn.microsoft.com/style-guide/welcome/) provides writing style and terminology guidance for all forms of technology communication, including the ASP.NET Core documentation.
 
 ## Redirects
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ASP.NET Docs
 
-This repository contains the conceptual ASP.NET 4.x documentation hosted in the [ASP.NET overview](https://docs.microsoft.com/aspnet/overview). See the [Contributing Guide](CONTRIBUTING.md) and the [issues list](https://github.com/dotnet/AspNetDocs/issues) if you would like to help out.
+This repository contains the conceptual ASP.NET 4.x documentation hosted in the [ASP.NET overview](https://learn.microsoft.com/aspnet/overview). See the [Contributing Guide](CONTRIBUTING.md) and the [issues list](https://github.com/dotnet/AspNetDocs/issues) if you would like to help out.
 
 API documentation changes should be made in the [ApiDocs repository](https://github.com/aspnet/ApiDocs) against the triple slash `///` comments.

--- a/aspnet/SameSite/owin-samesite.md
+++ b/aspnet/SameSite/owin-samesite.md
@@ -76,7 +76,7 @@ The 2019 draft of the `SameSite` specification:
 ## Supporting older browsers
 
 The 2016 `SameSite` standard mandated that unknown values must be treated as `SameSite=Strict` values. Apps accessed from older browsers which support the 2016 `SameSite` standard may break when they get a `SameSite` property with a value of `None`. Web apps must implement browser detection if they intend to support older browsers. ASP.NET doesn't implement browser detection because User-Agents values are highly volatile and change frequently. An extension point in [ICookieManager](/previous-versions/aspnet/dn800238(v%3Dvs.113)) allows plugging in User-Agent specific logic.
-<!-- https://docs.microsoft.com/previous-versions/aspnet/dn800238(v%3Dvs.113) -->
+<!-- https://learn.microsoft.com/previous-versions/aspnet/dn800238(v%3Dvs.113) -->
 
 In `Startup.Configuration`, add code similar to the following:
 

--- a/aspnet/aspnet/overview/developing-apps-with-windows-azure/building-real-world-cloud-apps-with-windows-azure/the-fix-it-sample-application.md
+++ b/aspnet/aspnet/overview/developing-apps-with-windows-azure/building-real-world-cloud-apps-with-windows-azure/the-fix-it-sample-application.md
@@ -209,7 +209,7 @@ There are two ways to run the Fix It app:
 <a id="runbase"></a>
 ### Run the base application
 
-1. Install [Visual Studio 2017](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=button+cta&utm_content=download+vs2017).
+1. Install [Visual Studio 2017](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=learn.microsoft.com&utm_campaign=button+cta&utm_content=download+vs2017).
 2. Install the [Azure SDK for .NET for Visual Studio](https://azure.microsoft.com/downloads/).
 3. Download the .zip file from the [MSDN Code Gallery](https://code.msdn.microsoft.com/Fix-It-app-for-Building-cdd80df4).
 4. In File Explorer, right-click the .zip file and click Properties, then in the Properties window click Unblock.

--- a/aspnet/mvc/overview/deployment/docker-aspnetmvc.md
+++ b/aspnet/mvc/overview/deployment/docker-aspnetmvc.md
@@ -33,7 +33,7 @@ The development machine must have the following software:
 
 - [Windows 10 Anniversary Update](https://www.microsoft.com/software-download/windows10) (or higher) or [Windows Server 2016](https://www.microsoft.com/cloud-platform/windows-server) (or higher)
 - [Docker for Windows](https://docs.docker.com/docker-for-windows/) - version Stable 1.13.0 or 1.12 Beta 26 (or newer versions)
-- [Visual Studio 2017](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=button+cta&utm_content=download+vs2017)
+- [Visual Studio 2017](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=learn.microsoft.com&utm_campaign=button+cta&utm_content=download+vs2017)
 
 > [!IMPORTANT]
 > If you are using Windows Server 2016, follow the instructions for [Container Host Deployment - Windows Server](/virtualization/windowscontainers/).

--- a/aspnet/mvc/overview/getting-started/getting-started-with-ef-using-mvc/creating-an-entity-framework-data-model-for-an-asp-net-mvc-application.md
+++ b/aspnet/mvc/overview/getting-started/getting-started-with-ef-using-mvc/creating-an-entity-framework-data-model-for-an-asp-net-mvc-application.md
@@ -45,7 +45,7 @@ In this tutorial, you:
 
 ## Prerequisites
 
-* [Visual Studio 2017](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=button+cta&utm_content=download+vs2017)
+* [Visual Studio 2017](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=learn.microsoft.com&utm_campaign=button+cta&utm_content=download+vs2017)
 
 ## Create an MVC web app
 

--- a/aspnet/mvc/overview/getting-started/introduction/getting-started.md
+++ b/aspnet/mvc/overview/getting-started/introduction/getting-started.md
@@ -15,7 +15,7 @@ by [Rick Anderson](https://twitter.com/RickAndMSFT)
 
 [!INCLUDE [consider RP](../../../../includes/razor.md)]
 
-This tutorial teaches you the basics of building an ASP.NET MVC 5 web app using [Visual Studio 2017](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=button+cta&utm_content=download+vs2017). The final source code for the tutorial is located on [GitHub](https://github.com/dotnet/AspNetDocs/tree/main/aspnet/mvc/overview/getting-started/introduction/sample/MvcMovie/MvcMovie).
+This tutorial teaches you the basics of building an ASP.NET MVC 5 web app using [Visual Studio 2017](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=learn.microsoft.com&utm_campaign=button+cta&utm_content=download+vs2017). The final source code for the tutorial is located on [GitHub](https://github.com/dotnet/AspNetDocs/tree/main/aspnet/mvc/overview/getting-started/introduction/sample/MvcMovie/MvcMovie).
 
 This tutorial was written by [Scott Guthrie](https://weblogs.asp.net/scottgu/) (twitter[@scottgu](https://twitter.com/scottgu) ), [Scott Hanselman](http://www.hanselman.com/blog/) (twitter: [@shanselman](https://twitter.com/shanselman) ), and [Rick Anderson](https://twitter.com/RickAndMSFT) ( [@RickAndMSFT](https://twitter.com/#!/RickAndMSFT) )
 
@@ -26,7 +26,7 @@ You need an Azure account to deploy this app to Azure:
 
 ## Get started
 
-Start by [installing Visual Studio 2017](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=button+cta&utm_content=download+vs2017). Then, open Visual Studio.
+Start by [installing Visual Studio 2017](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=learn.microsoft.com&utm_campaign=button+cta&utm_content=download+vs2017). Then, open Visual Studio.
 
 Visual Studio is an IDE, or integrated development environment. Just like you use Microsoft Word to write documents, you'll use an IDE to create applications. In Visual Studio, there's a list along the bottom showing various options available to you. There's also a menu that provides another way to perform tasks in the IDE. For example, instead of selecting **New Project** on the **Start page**, you can use the menu bar and select **File** > **New Project**.
 

--- a/aspnet/overview.md
+++ b/aspnet/overview.md
@@ -18,7 +18,7 @@ ASP.NET is a free web framework for building great websites and web applications
 
 ## Get started
 
-Install [Visual Studio](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=button+cta&utm_content=download+vs) Community edition, a free IDE for ASP.NET on Windows.
+Install [Visual Studio](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=learn.microsoft.com&utm_campaign=button+cta&utm_content=download+vs) Community edition, a free IDE for ASP.NET on Windows.
 
 ## Websites and web applications
 
@@ -103,7 +103,7 @@ Copy Web Deployment in Enterprise from WebForms to MVC
 Move under ASP.NET Best practices
 	What not to do in ASP​.NET, and what to do instead https://review.docs.microsoft.cus/aspnet/aspnet/overview/web-development-best-practices/what-not-to-do-in-aspnet-and-what-to-do-instead
 	Async and await https://channel9.msdn.com/Blogs/ASP-NET-Site-Videos/async-and-await
-	Building Real World Cloud Apps with Azure https://review.docs.microsoft.com/aspnet/aspnet/overview/developing-apps-with-windows-azure/building-real-world-cloud-apps-with-windows-azure/introduction
-	Hands on Lab: Maintainable Azure Websites: Managing Change and Scale https://review.docs.microsoft.com/aspnet/aspnet/overview/developing-apps-with-windows-azure/maintainable-azure-websites-managing-change-and-scale
+	Building Real World Cloud Apps with Azure https://review.learn.microsoft.com/aspnet/aspnet/overview/developing-apps-with-windows-azure/building-real-world-cloud-apps-with-windows-azure/introduction
+	Hands on Lab: Maintainable Azure Websites: Managing Change and Scale https://review.learn.microsoft.com/aspnet/aspnet/overview/developing-apps-with-windows-azure/maintainable-azure-websites-managing-change-and-scale
 
 -->

--- a/aspnet/signalr/overview/performance/using-signalr-performance-counters-in-an-azure-web-role.md
+++ b/aspnet/signalr/overview/performance/using-signalr-performance-counters-in-an-azure-web-role.md
@@ -20,7 +20,7 @@ SignalR performance counters are used to monitor your app's performance in an Az
 
 ## Prerequisites
 
-* Visual Studio 2015 or [2017](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=button+cta&utm_content=download+vs2017)
+* Visual Studio 2015 or [2017](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=learn.microsoft.com&utm_campaign=button+cta&utm_content=download+vs2017)
 * [Microsoft Azure SDK for Visual Studio](https://azure.microsoft.com/downloads/) **Note: Restart your machine after installing the SDK.**
 * Microsoft Azure subscription: To sign up for a free Azure trial account, see [Azure Free Trial](https://azure.microsoft.com/free/dotnet/).
 

--- a/aspnet/web-api/overview/advanced/configuring-aspnet-web-api.md
+++ b/aspnet/web-api/overview/advanced/configuring-aspnet-web-api.md
@@ -40,7 +40,7 @@ Web API configuration settings are defined in the [HttpConfiguration](https://ms
 
 ## Prerequisites
 
-[Visual Studio 2017](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=button+cta&utm_content=download+vs2017) Community, Professional, or Enterprise edition.
+[Visual Studio 2017](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=learn.microsoft.com&utm_campaign=button+cta&utm_content=download+vs2017) Community, Professional, or Enterprise edition.
 
 <a id="webhost"></a>
 ## Configuring Web API with ASP.NET Hosting

--- a/aspnet/web-api/overview/data/using-web-api-with-entity-framework/part-1.md
+++ b/aspnet/web-api/overview/data/using-web-api-with-entity-framework/part-1.md
@@ -18,7 +18,7 @@ msc.type: authoredcontent
 > ## Software versions used in the tutorial
 >
 > - Web API 2.1
-> - Visual Studio 2017 (download Visual Studio 2017 [here](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=button+cta&utm_content=download+vs2017))
+> - Visual Studio 2017 (download Visual Studio 2017 [here](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=learn.microsoft.com&utm_campaign=button+cta&utm_content=download+vs2017))
 > - Entity Framework 6
 > - .NET 4.7
 > - [Knockout.js](http://knockoutjs.com/) 3.1

--- a/aspnet/web-api/overview/getting-started-with-aspnet-web-api/tutorial-your-first-web-api.md
+++ b/aspnet/web-api/overview/getting-started-with-aspnet-web-api/tutorial-your-first-web-api.md
@@ -23,7 +23,7 @@ ASP.NET Web API is a framework for building web APIs on top of the .NET Framewor
 
 ## Software versions used in the tutorial
 
-- [Visual Studio 2017](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=button+cta&utm_content=download+vs2017)
+- [Visual Studio 2017](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=learn.microsoft.com&utm_campaign=button+cta&utm_content=download+vs2017)
 - Web API 2
 
 See [Create a web API with ASP.NET Core and Visual Studio for Windows](/aspnet/core/tutorials/first-web-api) for a newer version of this tutorial.

--- a/aspnet/web-api/overview/odata-support-in-aspnet-web-api/odata-v4/entity-relations-in-odata-v4.md
+++ b/aspnet/web-api/overview/odata-support-in-aspnet-web-api/odata-v4/entity-relations-in-odata-v4.md
@@ -21,7 +21,7 @@ by Mike Wasson
 >
 > - Web API 2.1
 > - OData v4
-> - Visual Studio 2017 (download Visual Studio 2017 [here](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=button+cta&utm_content=download+vs2017))
+> - Visual Studio 2017 (download Visual Studio 2017 [here](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=learn.microsoft.com&utm_campaign=button+cta&utm_content=download+vs2017))
 > - Entity Framework 6
 > - .NET 4.5
 >

--- a/aspnet/web-api/overview/odata-support-in-aspnet-web-api/odata-v4/odata-actions-and-functions.md
+++ b/aspnet/web-api/overview/odata-support-in-aspnet-web-api/odata-v4/odata-actions-and-functions.md
@@ -19,7 +19,7 @@ by Mike Wasson
 >
 > - Web API 2.2
 > - OData v4
-> - Visual Studio 2013 (download Visual Studio 2017 [here](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=button+cta&utm_content=download+vs2017))
+> - Visual Studio 2013 (download Visual Studio 2017 [here](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=learn.microsoft.com&utm_campaign=button+cta&utm_content=download+vs2017))
 > - .NET 4.5
 >
 > ## Tutorial versions

--- a/aspnet/web-api/overview/security/enabling-cross-origin-requests-in-web-api.md
+++ b/aspnet/web-api/overview/security/enabling-cross-origin-requests-in-web-api.md
@@ -25,7 +25,7 @@ Browser security prevents a web page from making AJAX requests to another domain
 
 ## Software used in the tutorial
 
-- [Visual Studio](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=button+cta&utm_content=download+vs2017)
+- [Visual Studio](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=learn.microsoft.com&utm_campaign=button+cta&utm_content=download+vs2017)
 - Web API 2.2
 
 ## Introduction

--- a/aspnet/web-api/overview/testing-and-debugging/mocking-entity-framework-when-unit-testing-aspnet-web-api-2.md
+++ b/aspnet/web-api/overview/testing-and-debugging/mocking-entity-framework-when-unit-testing-aspnet-web-api-2.md
@@ -23,7 +23,7 @@ by [Tom FitzMacken](https://github.com/tfitzmac)
 >
 > ## Software versions used in the tutorial
 >
-> - [Visual Studio 2017](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=button+cta&utm_content=download+vs2017)
+> - [Visual Studio 2017](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=learn.microsoft.com&utm_campaign=button+cta&utm_content=download+vs2017)
 > - Web API 2
 
 ## In this topic

--- a/aspnet/web-api/overview/testing-and-debugging/tracing-in-aspnet-web-api.md
+++ b/aspnet/web-api/overview/testing-and-debugging/tracing-in-aspnet-web-api.md
@@ -17,7 +17,7 @@ msc.type: authoredcontent
 >
 > ## Software versions used in the tutorial
 >
-> - [Visual Studio 2017](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=button+cta&utm_content=download+vs2017) (also works with Visual Studio 2015)
+> - [Visual Studio 2017](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=learn.microsoft.com&utm_campaign=button+cta&utm_content=download+vs2017) (also works with Visual Studio 2015)
 > - Web API 2
 > - [Microsoft.AspNet.WebApi.Tracing](http://www.nuget.org/packages/Microsoft.AspNet.WebApi.Tracing)
 

--- a/aspnet/web-api/overview/testing-and-debugging/unit-testing-controllers-in-web-api.md
+++ b/aspnet/web-api/overview/testing-and-debugging/unit-testing-controllers-in-web-api.md
@@ -17,7 +17,7 @@ msc.type: authoredcontent
 >
 > ## Software versions used in the tutorial
 >
-> - [Visual Studio 2017](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=button+cta&utm_content=download+vs2017)
+> - [Visual Studio 2017](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=learn.microsoft.com&utm_campaign=button+cta&utm_content=download+vs2017)
 > - Web API 2
 > - [Moq](https://github.com/Moq) 4.5.30
 

--- a/aspnet/web-api/overview/testing-and-debugging/unit-testing-with-aspnet-web-api.md
+++ b/aspnet/web-api/overview/testing-and-debugging/unit-testing-with-aspnet-web-api.md
@@ -23,7 +23,7 @@ by [Tom FitzMacken](https://github.com/tfitzmac)
 >
 > ## Software versions used in the tutorial
 >
-> - [Visual Studio 2017](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=button+cta&utm_content=download+vs2017)
+> - [Visual Studio 2017](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=learn.microsoft.com&utm_campaign=button+cta&utm_content=download+vs2017)
 > - Web API 2
 
 ## In this topic
@@ -43,7 +43,7 @@ This topic contains the following sections:
 <a id="prereqs"></a>
 ## Prerequisites
 
-[Visual Studio 2017](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=button+cta&utm_content=download+vs2017) Community, Professional or Enterprise edition
+[Visual Studio 2017](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=learn.microsoft.com&utm_campaign=button+cta&utm_content=download+vs2017) Community, Professional or Enterprise edition
 
 <a id="download"></a>
 ## Download code

--- a/aspnet/web-api/overview/web-api-routing-and-actions/attribute-routing-in-web-api-2.md
+++ b/aspnet/web-api/overview/web-api-routing-and-actions/attribute-routing-in-web-api-2.md
@@ -19,7 +19,7 @@ This topic shows how to enable attribute routing and describes the various optio
 
 ## Prerequisites
 
-[Visual Studio 2017](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=button+cta&utm_content=download+vs2017) Community, Professional, or Enterprise edition
+[Visual Studio 2017](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=learn.microsoft.com&utm_campaign=button+cta&utm_content=download+vs2017) Community, Professional, or Enterprise edition
 
 Alternatively, use NuGet Package Manager to install the necessary packages. From the **Tools** menu in Visual Studio, select **NuGet Package Manager**, then select **Package Manager Console**. Enter the following command in the Package Manager Console window:
 

--- a/aspnet/web-api/overview/web-api-routing-and-actions/create-a-rest-api-with-attribute-routing.md
+++ b/aspnet/web-api/overview/web-api-routing-and-actions/create-a-rest-api-with-attribute-routing.md
@@ -38,7 +38,7 @@ For most requests, however, the API will return a subset of this data (title, au
 
 ## Prerequisites
 
-[Visual Studio 2017](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=button+cta&utm_content=download+vs2017) Community, Professional or Enterprise edition.
+[Visual Studio 2017](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=learn.microsoft.com&utm_campaign=button+cta&utm_content=download+vs2017) Community, Professional or Enterprise edition.
 
 ## Create the Visual Studio Project
 

--- a/aspnet/web-pages/overview/getting-started/program-asp-net-web-pages-in-visual-studio.md
+++ b/aspnet/web-pages/overview/getting-started/program-asp-net-web-pages-in-visual-studio.md
@@ -32,7 +32,7 @@ by [Tom FitzMacken](https://github.com/tfitzmac)
 >
 > This tutorial also works with ASP.NET Web Pages 2, Visual Studio 2012, Visual Studio 2010, and WebMatrix 2.
 
-You can program ASP.NET Web pages with Razor syntax using WebMatrix or many other code editors. You can also use Microsoft Visual Studio which is a full-featured integrated development environment (IDE) that provides a powerful set of tools for creating many types of applications (not just websites). To work with ASP.NET Razor pages, you can use [Visual Studio 2017](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=button+cta&utm_content=download+vs2017).
+You can program ASP.NET Web pages with Razor syntax using WebMatrix or many other code editors. You can also use Microsoft Visual Studio which is a full-featured integrated development environment (IDE) that provides a powerful set of tools for creating many types of applications (not just websites). To work with ASP.NET Razor pages, you can use [Visual Studio 2017](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=learn.microsoft.com&utm_campaign=button+cta&utm_content=download+vs2017).
 
 Two particularly useful features that Visual Studio provides for programming with ASP.NET Razor web pages are:
 

--- a/aspnet/web-pages/overview/testing-and-debugging/introduction-to-debugging.md
+++ b/aspnet/web-pages/overview/testing-and-debugging/introduction-to-debugging.md
@@ -112,7 +112,7 @@ The `ObjectInfo` helper displays the type and the value of each object you pass 
 
 ## Using Debugging Tools in Visual Studio
 
-For a more comprehensive debugging experience, use [Visual Studio](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=button+cta&utm_content=download+vs2017). With Visual Studio, you can set a breakpoint in your code at the line that you want to inspect.
+For a more comprehensive debugging experience, use [Visual Studio](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=learn.microsoft.com&utm_campaign=button+cta&utm_content=download+vs2017). With Visual Studio, you can set a breakpoint in your code at the line that you want to inspect.
 
 ![set breakpoint](introduction-to-debugging/_static/image1.png)
 


### PR DESCRIPTION
**Global effort for the Microsoft Learn platform rebrand**

The Microsoft team is applying changes to content for the Microsoft Learn platform rebrand. Changes include modifications to current Microsoft Learn and Microsoft Docs terminology as well as associated domain name and content URL path changes.

**DO NOT MERGE THIS PULL REQUEST WHILE IN DRAFT STATUS!** Some of the changes to links and other content are not valid until after go-live.

Please review this draft PR and provide any necessary comments as soon as possible. Because these fixes are tightly scoped, we have approval to automatically merge these changes to the default branch for publication.

This PR was generated via DocuTune. It includes only targeted fixes and minor formatting adjustments.

CorrelationId: d8c4c3ac-d49a-4c95-9ddc-9822ca297907
InitiativeId: docutune-rebranding-2022-09
PointOfContact: Alex Buck
