### PR TITLE
Missing more info reference

### DIFF
--- a/aspnet/web-api/overview/releases/whats-new-in-aspnet-web-api-odata-53.md
+++ b/aspnet/web-api/overview/releases/whats-new-in-aspnet-web-api-odata-53.md
@@ -56,7 +56,7 @@ This query is equivalent to:
 <a id="open-entity-types"></a>
 ### Support for Open Entity Types
 
-An *open type* is a structured type that contains dynamic properties, in addition to any properties that are declared in the type definition. Open types let you add flexibility to your data models. For more information, see xxxx.
+  An *open type* is a structured type that contains dynamic properties, in addition to any properties that are declared in the type definition. Open types let you add flexibility to your data models. For more information, see [Open Types in OData v4 with ASP.NET Web API](https://learn.microsoft.com/en-us/aspnet/web-api/overview/odata-support-in-aspnet-web-api/odata-v4/use-open-types-in-odata-v4).
 
 ### Support for dynamic collection properties in open types
 

--- a/aspnet/web-api/overview/releases/whats-new-in-aspnet-web-api-odata-53.md
+++ b/aspnet/web-api/overview/releases/whats-new-in-aspnet-web-api-odata-53.md
@@ -56,7 +56,7 @@ This query is equivalent to:
 <a id="open-entity-types"></a>
 ### Support for Open Entity Types
 
-  An *open type* is a structured type that contains dynamic properties, in addition to any properties that are declared in the type definition. Open types let you add flexibility to your data models. For more information, see [Open Types in OData v4 with ASP.NET Web API](https://learn.microsoft.com/en-us/aspnet/web-api/overview/odata-support-in-aspnet-web-api/odata-v4/use-open-types-in-odata-v4).
+  An *open type* is a structured type that contains dynamic properties, in addition to any properties that are declared in the type definition. Open types let you add flexibility to your data models. For more information, see [Open Types in OData v4 with ASP.NET Web API](/aspnet/web-api/overview/odata-support-in-aspnet-web-api/odata-v4/use-open-types-in-odata-v4).
 
 ### Support for dynamic collection properties in open types
 


### PR DESCRIPTION
In 'Support for Open Entity Types' section, more information reference is missing the details/link to the page.  Not sure if this is the right reference page to update with: https://learn.microsoft.com/en-us/aspnet/web-api/overview/odata-support-in-aspnet-web-api/odata-v4/use-open-types-in-odata-v4



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->