### PR TITLE
Fixed invalid markdown in deploy to azure button

### DIFF
--- a/aspnet/web-pages/overview/getting-started/introducing-aspnet-web-pages-2/getting-started.md
+++ b/aspnet/web-pages/overview/getting-started/introducing-aspnet-web-pages-2/getting-started.md
@@ -112,7 +112,7 @@ Subsequent tutorial sets build on this set and add more functionality, like uplo
 
 Would you like to see the finished site running as a live web app? You can deploy a complete version of the app to your Azure account by simply clicking the following button.
 
-![Button for the Azure deployment function.](http://azuredeploy.net/deploybutton.png)](https://azuredeploy.net/?WT.mc_id=deploy_azure_aspnet&repository=https://github.com/tfitzmac/WebPagesMovies)
+[![Button for the Azure deployment function.](http://azuredeploy.net/deploybutton.png)](https://azuredeploy.net/?WT.mc_id=deploy_azure_aspnet&repository=https://github.com/tfitzmac/WebPagesMovies)
 
 You need an Azure account to deploy this solution to Azure. If you do not already have an account, you have the following options:
 


### PR DESCRIPTION
A `[` is missing in front of the Deploy to azure button for this to show as a clickable button.