### PR TITLE
Update regex in example to reflect text

### DIFF
--- a/aspnet/mvc/overview/getting-started/introduction/adding-validation/samples/sample1.cs
+++ b/aspnet/mvc/overview/getting-started/introduction/adding-validation/samples/sample1.cs
@@ -10,7 +10,7 @@ public class Movie
     [DisplayFormat(DataFormatString = "{0:yyyy-MM-dd}", ApplyFormatInEditMode = true)]
     public DateTime ReleaseDate { get; set; }
   
-    [RegularExpression(@"^[A-Z]+[a-zA-Z'\s]*$")]
+    [RegularExpression(@"^[A-Z]+[a-zA-Z]*$")]
     [Required]
     [StringLength(30)]
     public string Genre { get; set; }
@@ -19,7 +19,7 @@ public class Movie
     [DataType(DataType.Currency)]
     public decimal Price { get; set; }
 
-    [RegularExpression(@"^[A-Z]+[a-zA-Z'\s]*$")]
+    [RegularExpression(@"^[A-Z]+[a-zA-Z]*$")]
     [StringLength(5)]
     public string Rating { get; set; }
 }


### PR DESCRIPTION
The text description and the code do not match. 

The text says "The RegularExpression attribute is used to limit what characters can be input. In the code above, Genre and Rating must use only letters (white space, numbers and special characters are not allowed)." while the regex allows white space and apostrophes. We could also change the text to match the regex, but this seems easier.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->