### PR TITLE
Update asp-net-mvc-routing-overview-cs.md

### DIFF
--- a/aspnet/mvc/overview/older-versions-1/controllers-and-routing/asp-net-mvc-routing-overview-cs.md
+++ b/aspnet/mvc/overview/older-versions-1/controllers-and-routing/asp-net-mvc-routing-overview-cs.md
@@ -15,7 +15,7 @@ by [Stephen Walther](https://github.com/StephenWalther)
 
 > In this tutorial, Stephen Walther shows how the ASP.NET MVC framework maps browser requests to controller actions.
 
-In this tutorial, you are introduced to an important feature of every ASP.NET MVC application called *ASP.NET Routing*. The ASP.NET Routing module is responsible for mapping incoming browser requests to particular MVC controller actions. By the end of this tutorial, you will understand how the standard route table maps requests to controller actions.
+In this tutorial, you are introduced to an important feature of every ASP.NET MVC application called *ASP.NET Routing*. The ASP.NET Routing module is responsible for mapping incoming requests to particular MVC controller actions. By the end of this tutorial, you will understand how the standard route table maps requests to controller actions.
 
 ## Using the Default Route Table
 


### PR DESCRIPTION
Remove word "browser" from "The ASP.NET Routing module is responsible for mapping incoming browser requests to particular MVC controller actions"
<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->