### PR TITLE
[BULK] Validation fixes (remove links to nonexistent art)

### DIFF
--- a/aspnet/single-page-application/overview/templates/breezeangular-template.md
+++ b/aspnet/single-page-application/overview/templates/breezeangular-template.md
@@ -21,15 +21,9 @@ by [Mads Kristensen](https://github.com/madskristensen)
 
 The Breeze/Angular SPA template is a variation on the [KnockoutJS SPA template](../introduction/knockoutjs-template.md) included in the ASP.NET and Web Tools 2012.2 Update. If you've got Visual Studio, you'll have an example SPA up and running in less than 60 seconds.
 
-:::image type="icon" source="http://www.breezejs.com/sites/all/images/spa-template/NgRunningTodoPage.png":::
+Outwardly, the application looks very similar to the KnockoutJS SPA template. But it's quite different under the hood. The KnockoutJS template uses Knockout for data binding and raw AJAX for data access. The Breeze/Angular template uses Angular for data binding and Breeze for data access. These libraries enable additional capabilities, including page navigation and history.
 
-Outwardly, the application looks the very similar to the KnockoutJS SPA template. But it's quite different under the hood. The KnockoutJS template uses Knockout for data binding and raw AJAX for data access. The Breeze/Angular template uses Angular for data binding and Breeze for data access. These libraries enable additional capabilities, including page navigation and history.
-
-Here is the application's About page:
-
-:::image type="icon" source="http://www.breezejs.com/sites/all/images/spa-template/NgRunningAboutPage.png":::
-
-This page displays a running log of events during the current user session, including:
+The application's About page displays a running log of events during the current user session, including:
 
 - Paging. Note the Todo controller creation at #2 and #7.
 - Remote queries (#3) and local cache queries (#7).
@@ -56,15 +50,9 @@ In the **Templates** pane, select **Installed Templates** and expand the **Visua
 
 In the **New Project** wizard, select **Breeze Angular SPA**.
 
-:::image type="icon" source="http://www.breezejs.com/sites/all/images/spa-template/SelectBreezeNgSpaTemplate.png":::
-
 Press Ctrl-F5 to build and run the application without debugging, or press F5 to run with debugging.
 
-:::image type="icon" source="http://www.breezejs.com/sites/all/images/spa-template/ZephyrLogin.png":::
-
 When the application first runs, it displays a login screen. Click the "Sign up" link and a new page glides into view, where you can enter a username and password. (The login and registration pages are built using ASP.NET MVC.) When you submit the registration form, the server generates a TodoList with two items for your account. Then it presents them to you on a yellow note.
-
-:::image type="icon" source="http://www.breezejs.com/sites/all/images/spa-template/TodoList.png":::
 
 Now you are in the land of SPA. Everything you see and experience while manipulating Todos is rendered and managed on the client with the help of Knockout and Breeze. Explore the app as a user … but with a developer's eye. Use the developer tools in your browser to capture the network traffic. (In Internet Explorer: Press F12, select the **Network** tab, and click **Start capturing**.) Now try the following:
 
@@ -90,15 +78,11 @@ Also, notice there is no network traffic when you switch between the TodoList an
 
 This application has a client side and a server side. The client-side stack consists of a little HTML and a combination of application JavaScript modules (in the "app" folder) plus third-party JavaScript libraries (in the "Scripts" folder).
 
-:::image type="icon" source="http://www.breezejs.com/sites/all/images/spa-template/NgClientArchitecture2.png":::
-
 The UI architecture separates the HTML widgets of the views from the supporting presentation code in the controllers. The Angular data-binding system coordinates views and controllers so that each can do its job without intimate knowledge of the other.
 
 The controller asks the data context to acquire and save the model entities. The data context delegates most of the work to Breeze, which constructs self-tracking model objects from JSON query results.
 
-The server-side stack consists of some developer code and three principle .NET libraries: Web API, Entity Framework, and Breeze.NET:
-
-:::image type="icon" source="http://www.breezejs.com/sites/all/images/spa-template/ServerArchitecture.png":::
+The server-side stack consists of some developer code and three principal .NET libraries: Web API, Entity Framework, and Breeze.NET.
 
 The basic architecture is the same as the KnockoutJS SPA template. However, the implementation is much simpler: The DTOs were deleted, and most of the Entity Framework details have been delegated to Breeze.NET.
 

--- a/aspnet/single-page-application/overview/templates/breezeangular-template.md
+++ b/aspnet/single-page-application/overview/templates/breezeangular-template.md
@@ -25,10 +25,10 @@ Outwardly, the application looks very similar to the KnockoutJS SPA template. Bu
 
 The application's About page displays a running log of events during the current user session, including:
 
-- Paging. Note the Todo controller creation at #2 and #7.
-- Remote queries (#3) and local cache queries (#7).
-- Saving new (#5, #6) and modified (#4) entities.
-- Changes validated on the client (#9), so the user can correct mistakes before committing changes to the database.
+- Paging. Note the Todo controller creation.
+- Remote queries and local cache queries.
+- Saving new and modified entities.
+- Changes validated on the client, so the user can correct mistakes before committing changes to the database.
 
 There's more to explore in this template, including:
 

--- a/aspnet/single-page-application/overview/templates/breezeknockout-template.md
+++ b/aspnet/single-page-application/overview/templates/breezeknockout-template.md
@@ -20,8 +20,6 @@ by [Mads Kristensen](https://github.com/madskristensen)
 
 You've heard of "single page application" (SPA) and wondered what it is. While you could read about it, you'd rather experience it for yourself. But who has time to download a sample? If you've got Visual Studio, you'll have an example SPA up and running in less than 60 seconds with the ASP.NET MVC 4 "Breeze/Knockout Single Page Application" template.
 
-:::image type="content" source="http://www.breezejs.com/sites/all/images/spa-template/ZephyrRunning.png" alt-text="Screenshot of the Breeze Knockout Single Page Application template.":::
-
 ## What is the Breeze/Knockout SPA Template?
 
 Most project templates generate an application skeleton. You put flesh on those bones by adding your code and eventually deliver a working application. The Breeze/Knockout SPA template is different. It generates a sample application for you to study. It demonstrates a SPA application design and many of the techniques for building a SPA.
@@ -52,15 +50,9 @@ In the **Templates** pane, select **Installed Templates** and expand the **Visua
 
 In the **New Project** wizard, select **Breeze Knockout SPA**.
 
-:::image type="content" source="http://www.breezejs.com/sites/all/images/spa-template/SelectBreezeKOSpaTemplate.png" alt-text="Screenshot of the Templates pane in Visual Studio to select Installed Templates.":::
-
 Press Ctrl-F5 to build and run the application without debugging, or press F5 to run with debugging.
 
-:::image type="content" source="http://www.breezejs.com/sites/all/images/spa-template/ZephyrRunning.png" alt-text="Screenshot of the application to run with or without debugging.":::
-
 When the application first runs, it displays a login screen. Click the "Sign up" link and a new page glides into view, where you can enter a username and password. (The login and registration pages are built using ASP.NET MVC.) When you submit the registration form, the server generates a TodoList with two items for your account. Then it presents them to you on a yellow note.
-
-:::image type="content" source="http://www.breezejs.com/sites/all/images/spa-template/TodoList.png" alt-text="Screenshot of the To do List with two items for your account on a yellow note.":::
 
 Now you are in the land of SPA. Everything you see and experience while manipulating Todos is rendered and managed on the client with the help of Knockout and Breeze. Explore the app as a user … but with a developer's eye. Use the developer tools in your browser to capture the network traffic. (In Internet Explorer: Press F12, select the **Network** tab, and click **Start capturing**.) Now try the following:
 
@@ -83,15 +75,11 @@ Review the network traffic. Notice that there were no calls to the server when B
 
 This application has a client side and a server side. The client-side stack consists of a little HTML and a combination of application JavaScript modules (in the "app" folder) plus third-party JavaScript libraries (in the "Scripts" folder).
 
-:::image type="content" source="http://www.breezejs.com/sites/all/images/spa-template/ClientArchitecture.png" alt-text="Screenshot of the Client Architecture of the application having a client side and a server side.":::
-
 If you've investigated the KnockoutJS SPA template, this should look very familiar. Focus on the blue boxes. The UI architecture is Model-View-ViewModel (MVVM), in which the HTML widgets of the view are cleanly separated from the supporting presentation code in the view-model. A data binding system (Knockout in this case) coordinates the view and view-model so that each can do its job without intimate knowledge of the other.
 
 The model encapsulates the Todo data. Entities in the model are constructed by Breeze with Knockout observable properties, so they can be bound directly to widgets in the view. The view-model asks the data context to acquire and save the model entities. The data context delegates most of the work to Breeze.
 
-The server-side stack consists of some developer code and three principle .NET libraries: Web API, Entity Framework, and Breeze.NET:
-
-:::image type="content" source="http://www.breezejs.com/sites/all/images/spa-template/ServerArchitecture.png" alt-text="Screenshot of the Server Architecture with details about the server side stack.":::
+The server-side stack consists of some developer code and three principal .NET libraries: Web API, Entity Framework, and Breeze.NET.
 
 The basic architecture is the same as the KnockoutJS SPA template. However, the implementation is much simpler: The DTOs were deleted, and most of the Entity Framework details have been delegated to Breeze.NET.
 

--- a/aspnet/single-page-application/overview/templates/breezeknockout-template.md
+++ b/aspnet/single-page-application/overview/templates/breezeknockout-template.md
@@ -85,7 +85,7 @@ The basic architecture is the same as the KnockoutJS SPA template. However, the 
 
 ## Next Steps
 
-We suggest that you explore the code, guided by the [extensive discussion](http://www.breezejs.com/spa-template?utm_source=ms-spa) of both the client and the server stacks on the Breeze website.
+We suggest that you explore the code, guided by the extensive discussion of both the client and the server stacks on the Breeze website.
 
 You might try playing with Breeze client-side query; add some filters and sorts. You might add more model properties and more entities to get a better feel for end-to-end SPA development. When you are confident of the design, you can tear out the Todo features and replace them with your own.
 


### PR DESCRIPTION
For User Story https://dev.azure.com/msft-skilling/Content/_workitems/edit/98992: VALIDATION: AspNetDocs/AspNetCore

Removes broken image links to nonexistent site `http://www.breezejs.com/sites/all/images/spa-template/*` from _breezeangular-template.md_ and _breezeknockout-template.md_. Removes all graphics from these articles.

The articles are 10 years old and require Visual Studio 2012 so are outdated, but the screenshots aren't necessary for following the procedures. However, pulled the articles out into a separate PR in case something else needs to be done with them.
<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->