### PR TITLE
Update for API test tooling, remove link.

### DIFF
--- a/aspnet/web-api/overview/security/enabling-cross-origin-requests-in-web-api.md
+++ b/aspnet/web-api/overview/security/enabling-cross-origin-requests-in-web-api.md
@@ -164,7 +164,7 @@ Here is an example response, assuming that the server allows the request:
 
 The response includes an Access-Control-Allow-Methods header that lists the allowed methods, and optionally an Access-Control-Allow-Headers header, which lists the allowed headers. If the preflight request succeeds, the browser sends the actual request, as described earlier.
 
-Tools commonly used to test endpoints with preflight OPTIONS requests (for example, [Fiddler](https://www.telerik.com/fiddler) and [Postman](https://www.getpostman.com/)) don't send the required OPTIONS headers by default. Confirm that the `Access-Control-Request-Method` and `Access-Control-Request-Headers` headers are sent with the request and that OPTIONS headers reach the app through IIS.
+Tools commonly used to test endpoints with preflight OPTIONS requests don't send the required OPTIONS headers by default. Confirm that the `Access-Control-Request-Method` and `Access-Control-Request-Headers` headers are sent with the request and that OPTIONS headers reach the app through IIS.
 
 To configure IIS to allow an ASP.NET app to receive and handle OPTION requests, add the following configuration to the app's *web.config* file in the `<system.webServer><handlers>` section:
 


### PR DESCRIPTION
[Internal Review: Section: How CORS works](https://review.learn.microsoft.com/en-us/aspnet/web-api/overview/security/enabling-cross-origin-requests-in-web-api?branch=pr-en-us-885#how-cors-works)

Fixes dotnet/aspnetcore.docs#31981

Removed API test tool links.  It was not needed in the instructions, and no matter the tool, good to confirm OPTIONS headers reach the app as directed in that section.

Related to dotnet/aspnetcore.docs#31965