### PR TITLE
Broken link in model-validation-in-aspnet-web-api.md

### DIFF
--- a/aspnet/web-api/overview/formats-and-model-binding/model-validation-in-aspnet-web-api.md
+++ b/aspnet/web-api/overview/formats-and-model-binding/model-validation-in-aspnet-web-api.md
@@ -55,6 +55,7 @@ You don't want users to update the `IsAdmin` property and elevate themselves to 
 
 [!code-csharp[Main](model-validation-in-aspnet-web-api/samples/sample8.cs)]
 
+<!-- The link to the blog post bellow is broken, it redirects to the home page of the blog. Maybe @bradwilson could help. -->
 > [!NOTE]
 > Brad Wilson's blog post "[Input Validation vs. Model Validation in ASP.NET MVC](https://bradwilson.typepad.com/blog/2010/01/input-validation-vs-model-validation-in-aspnet-mvc.html)" has a good discussion of under-posting and over-posting. Although the post is about ASP.NET MVC 2, the issues are still relevant to Web API.
 


### PR DESCRIPTION
The following blog post link on line [59](https://github.com/dotnet/AspNetDocs/blob/40dadb9d0bc36de1087802db1254e1c03f3f46fb/aspnet/web-api/overview/formats-and-model-binding/model-validation-in-aspnet-web-api.md?plain=1#L59) is broken: [Input Validation vs. Model Validation in ASP.NET MVC](https://bradwilson.typepad.com/blog/2010/01/input-validation-vs-model-validation-in-aspnet-mvc.html).
Maybe @bradwilson could help provide a new link.
I couldn't find any way to create an issue instead of a pull request.

<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->