### PR TITLE
Update docker mvc migration docker image url

### DIFF
--- a/aspnet/mvc/overview/deployment/docker-aspnetmvc.md
+++ b/aspnet/mvc/overview/deployment/docker-aspnetmvc.md
@@ -69,7 +69,7 @@ Click **Publish**, and Visual Studio will copy all the needed assets to the dest
 Create a new file named *Dockerfile* to define your Docker image. *Dockerfile* contains instructions to build the final image and includes any base image names, required components, the app you want to run, and other configuration images. *Dockerfile* is the input to the `docker build` command that creates the image.
 
 For this exercise, you will build an image based on the `microsoft/aspnet`
-image located on [Docker Hub](https://hub.docker.com/r/microsoft/dotnet-framework/).
+image located on [Docker Hub](https://hub.docker.com/r/microsoft/dotnet-framework-aspnet).
 The base image, `mcr.microsoft.com/dotnet/framework/aspnet:4.8`, is a Windows Server image. It contains
 Windows Server Core, IIS, and ASP.NET 4.8. When you run this image in your container, it will automatically start IIS and installed websites.
 

--- a/aspnet/mvc/overview/deployment/docker-aspnetmvc.md
+++ b/aspnet/mvc/overview/deployment/docker-aspnetmvc.md
@@ -69,9 +69,9 @@ Click **Publish**, and Visual Studio will copy all the needed assets to the dest
 Create a new file named *Dockerfile* to define your Docker image. *Dockerfile* contains instructions to build the final image and includes any base image names, required components, the app you want to run, and other configuration images. *Dockerfile* is the input to the `docker build` command that creates the image.
 
 For this exercise, you will build an image based on the `microsoft/aspnet`
-image located on [Docker Hub](https://hub.docker.com/r/microsoft/aspnet/).
-The base image, `microsoft/aspnet`, is a Windows Server image. It contains
-Windows Server Core, IIS, and ASP.NET 4.7.2. When you run this image in your container, it will automatically start IIS and installed websites.
+image located on [Docker Hub](https://hub.docker.com/r/microsoft/dotnet-framework/).
+The base image, `mcr.microsoft.com/dotnet/framework/aspnet:4.8`, is a Windows Server image. It contains
+Windows Server Core, IIS, and ASP.NET 4.8. When you run this image in your container, it will automatically start IIS and installed websites.
 
 The Dockerfile that creates your image looks like this:
 

--- a/aspnet/mvc/overview/deployment/docker-aspnetmvc.md
+++ b/aspnet/mvc/overview/deployment/docker-aspnetmvc.md
@@ -77,9 +77,9 @@ The Dockerfile that creates your image looks like this:
 
 ```console
 # The `FROM` instruction specifies the base image. You are
-# extending the `microsoft/aspnet` image.
+# extending the `mcr.microsoft.com/dotnet/framework/aspnet:4.8` image.
 
-FROM microsoft/aspnet
+FROM mcr.microsoft.com/dotnet/framework/aspnet:4.8
 
 # The final instruction copies the site you published earlier into the container.
 COPY ./bin/Release/PublishOutput/ /inetpub/wwwroot

--- a/aspnet/mvc/overview/deployment/docker-aspnetmvc/samples/MVCRandomAnswerGenerator/Dockerfile
+++ b/aspnet/mvc/overview/deployment/docker-aspnetmvc/samples/MVCRandomAnswerGenerator/Dockerfile
@@ -1,7 +1,7 @@
 # The `FROM` instruction specifies the base image. You are
-# extending the `microsoft/aspnet` image.
+# extending the `mcr.microsoft.com/dotnet/framework/aspnet:4.8` image.
 
-FROM microsoft/aspnet
+FROM mcr.microsoft.com/dotnet/framework/aspnet:4.8
 
 # Next, this Dockerfile creates a directory for your application
 RUN mkdir C:\randomanswers


### PR DESCRIPTION
The current code in the documentation doesn't work. After a bit of digging I found https://hub.docker.com/r/microsoft/dotnet-framework/ and https://github.com/microsoft/dotnet-framework-docker/blob/main/samples/aspnetmvcapp/Dockerfile as an example.

Based on those I updated the text and example dockerfile.