### PR TITLE
UUF - Fix video links for the net-4 series web forms

### DIFF
--- a/aspnet/web-forms/videos/net-4/routing/aspnet-4-quick-hit-declarative-webforms-routing.md
+++ b/aspnet/web-forms/videos/net-4/routing/aspnet-4-quick-hit-declarative-webforms-routing.md
@@ -4,7 +4,7 @@ title: ASP.NET 4 Quick Hit - Declarative WebForms Routing
 author: JoeStagner
 description: "In this video you will learn how to do WebForms routing declaratively through markup."
 ms.author: riande
-ms.date: 11/11/2009
+ms.date: 10/02/2024
 ms.assetid: bfeb728e-3216-4310-8303-6cdb79255c15
 msc.legacyurl: /web-forms/videos/net-4/routing/aspnet-4-quick-hit-declarative-webforms-routing
 msc.type: video
@@ -15,7 +15,7 @@ by [Joe Stagner](https://github.com/JoeStagner)
 
 In this video you will learn how to do WebForms routing declaratively through markup. 
 
-[&#9654; Watch video (14 minutes)](https://channel9.msdn.com/Blogs/ASP-NET-Site-Videos/aspnet-4-quick-hit-declarative-webforms-routing)
+[&#9654; Watch video (14 minutes)](/shows/asp-net-site-videos/aspnet-4-quick-hit-declarative-webforms-routing)
 
 > [!div class="step-by-step"]
 > [Previous](aspnet-4-quick-hit-imperative-webforms-routing.md)

--- a/aspnet/web-forms/videos/net-4/routing/aspnet-4-quick-hit-imperative-webforms-routing.md
+++ b/aspnet/web-forms/videos/net-4/routing/aspnet-4-quick-hit-imperative-webforms-routing.md
@@ -4,7 +4,7 @@ title: ASP.NET 4 Quick Hit - Imperative WebForms Routing
 author: JoeStagner
 description: "In this video you will learn how to use an expression builder to do WebForms routing imperatively."
 ms.author: riande
-ms.date: 11/05/2009
+ms.date: 10/02/2024
 ms.assetid: c78fd810-4309-4d58-afd9-81e9ffa77429
 msc.legacyurl: /web-forms/videos/net-4/routing/aspnet-4-quick-hit-imperative-webforms-routing
 msc.type: video
@@ -15,7 +15,7 @@ by [Joe Stagner](https://github.com/JoeStagner)
 
 In this video you will learn how to use an expression builder to do WebForms routing imperatively. 
 
-[&#9654; Watch video (12 minutes)](https://channel9.msdn.com/Blogs/ASP-NET-Site-Videos/aspnet-4-quick-hit-imperative-webforms-routing)
+[&#9654; Watch video (12 minutes)](/shows/asp-net-site-videos/aspnet-4-quick-hit-imperative-webforms-routing)
 
 > [!div class="step-by-step"]
 > [Previous](aspnet-4-quick-hit-permanent-redirect.md)

--- a/aspnet/web-forms/videos/net-4/routing/aspnet-4-quick-hit-outbound-webforms-routing.md
+++ b/aspnet/web-forms/videos/net-4/routing/aspnet-4-quick-hit-outbound-webforms-routing.md
@@ -4,7 +4,7 @@ title: Outbound WebForms Routing | Microsoft Docs
 author: JoeStagner
 description: "In this video you will see how to use the routing mechanism to dynamically create an outbound URL based on input from the user."
 ms.author: riande
-ms.date: 11/11/2009
+ms.date: 10/02/2024
 ms.assetid: 90d79218-505c-4b6d-87f5-a59592d59ccc
 msc.legacyurl: /web-forms/videos/net-4/routing/aspnet-4-quick-hit-outbound-webforms-routing
 msc.type: video
@@ -15,7 +15,7 @@ by [Joe Stagner](https://github.com/JoeStagner)
 
 In this video you will see how to use the routing mechanism to dynamically create an outbound URL based on input from the user. 
 
-[&#9654; Watch video (6 minutes)](https://channel9.msdn.com/Blogs/ASP-NET-Site-Videos/aspnet-4-quick-hit-outbound-webforms-routing)
+[&#9654; Watch video (6 minutes)](/shows/asp-net-site-videos/aspnet-4-quick-hit-outbound-webforms-routing)
 
 > [!div class="step-by-step"]
 > [Previous](aspnet-4-quick-hit-declarative-webforms-routing.md)

--- a/aspnet/web-forms/videos/net-4/routing/aspnet-4-quick-hit-permanent-redirect.md
+++ b/aspnet/web-forms/videos/net-4/routing/aspnet-4-quick-hit-permanent-redirect.md
@@ -4,7 +4,7 @@ title: Permanent Redirect | Microsoft Docs
 author: JoeStagner
 description: "In this video you will learn how to use the RedirectPermanent helper method to issue HTTP 301 responses."
 ms.author: riande
-ms.date: 11/05/2009
+ms.date: 10/02/2024
 ms.assetid: adea2a1f-4650-4e3d-8bff-3ff5cd22f895
 msc.legacyurl: /web-forms/videos/net-4/routing/aspnet-4-quick-hit-permanent-redirect
 msc.type: video
@@ -15,7 +15,7 @@ by [Joe Stagner](https://github.com/JoeStagner)
 
 In this video you will learn how to use the RedirectPermanent helper method to issue HTTP 301 responses. 
 
-[&#9654; Watch video (5 minutes)](https://channel9.msdn.com/Blogs/ASP-NET-Site-Videos/aspnet-4-quick-hit-permanent-redirect)
+[&#9654; Watch video (5 minutes)](/shows/asp-net-site-videos/aspnet-4-quick-hit-permanent-redirect)
 
 > [!div class="step-by-step"]
 > [Next](aspnet-4-quick-hit-imperative-webforms-routing.md)

--- a/aspnet/web-forms/videos/net-4/routing/how-do-i-use-routing-with-aspnet-web-forms.md
+++ b/aspnet/web-forms/videos/net-4/routing/how-do-i-use-routing-with-aspnet-web-forms.md
@@ -4,7 +4,7 @@ title: "How Do I: Use Routing with ASP.NET Web Forms? | Microsoft Docs"
 author: rick-anderson
 description: "In this video Chris Pels shows how to implement routing for Web Forms in ASP.NET 4. First, the concept of routing a URL is compared to mapping the URL to a p..."
 ms.author: riande
-ms.date: 10/15/2010
+ms.date: 10/02/2024
 ms.assetid: a3ab6cd9-8f71-4b73-9336-21c0de078269
 msc.legacyurl: /web-forms/videos/net-4/routing/how-do-i-use-routing-with-aspnet-web-forms
 msc.type: video
@@ -15,7 +15,7 @@ by [Chris Pels](https://twitter.com/chrispels)
 
 In this video Chris Pels shows how to implement routing for Web Forms in ASP.NET 4. First, the concept of routing a URL is compared to mapping the URL to a physical file in the site. Then, a sample route for a URL is defined in the global.asax file Application\_Start event handler. The route contains a parameterized value that the user can enter in the URL. A sample page is then created and the route parameter value is extracted in the Page\_Load event handler. Next, a second route is defined that has multiple parameters and routes to the same page as the initial route. The Page\_Load event handler is expanded to extract the additional route parameter value and display different information depending upon what values have been passed to the page.
 
-[&#9654; Watch video (15 minutes)](https://channel9.msdn.com/Blogs/ASP-NET-Site-Videos/how-do-i-use-routing-with-aspnet-web-forms)
+[&#9654; Watch video (15 minutes)](/shows/asp-net-site-videos/how-do-i-use-routing-aspnet-web-forms)
 
 > [!div class="step-by-step"]
 > [Previous](aspnet-4-quick-hit-outbound-webforms-routing.md)

--- a/aspnet/web-forms/videos/net-4/routing/how-do-i-use-routing-with-aspnet-web-forms.md
+++ b/aspnet/web-forms/videos/net-4/routing/how-do-i-use-routing-with-aspnet-web-forms.md
@@ -4,7 +4,7 @@ title: "How Do I: Use Routing with ASP.NET Web Forms? | Microsoft Docs"
 author: rick-anderson
 description: "In this video Chris Pels shows how to implement routing for Web Forms in ASP.NET 4. First, the concept of routing a URL is compared to mapping the URL to a p..."
 ms.author: riande
-ms.date: 10/02/2024
+ms.date: 10/01/2024
 ms.assetid: a3ab6cd9-8f71-4b73-9336-21c0de078269
 msc.legacyurl: /web-forms/videos/net-4/routing/how-do-i-use-routing-with-aspnet-web-forms
 msc.type: video

--- a/aspnet/web-forms/videos/net-4/routing/how-do-i-use-routing-with-aspnet-web-forms.md
+++ b/aspnet/web-forms/videos/net-4/routing/how-do-i-use-routing-with-aspnet-web-forms.md
@@ -4,7 +4,7 @@ title: "How Do I: Use Routing with ASP.NET Web Forms? | Microsoft Docs"
 author: rick-anderson
 description: "In this video Chris Pels shows how to implement routing for Web Forms in ASP.NET 4. First, the concept of routing a URL is compared to mapping the URL to a p..."
 ms.author: riande
-ms.date: 10/01/2024
+ms.date: 10/02/2024
 ms.assetid: a3ab6cd9-8f71-4b73-9336-21c0de078269
 msc.legacyurl: /web-forms/videos/net-4/routing/how-do-i-use-routing-with-aspnet-web-forms
 msc.type: video
@@ -15,7 +15,7 @@ by [Chris Pels](https://twitter.com/chrispels)
 
 In this video Chris Pels shows how to implement routing for Web Forms in ASP.NET 4. First, the concept of routing a URL is compared to mapping the URL to a physical file in the site. Then, a sample route for a URL is defined in the global.asax file Application\_Start event handler. The route contains a parameterized value that the user can enter in the URL. A sample page is then created and the route parameter value is extracted in the Page\_Load event handler. Next, a second route is defined that has multiple parameters and routes to the same page as the initial route. The Page\_Load event handler is expanded to extract the additional route parameter value and display different information depending upon what values have been passed to the page.
 
-[&#9654; Watch video (15 minutes)](/shows/asp-net-site-videos/how-do-i-use-routing-aspnet-web-forms)
+[&#9654; Watch video (15 minutes)](https://learn.microsoft.com/shows/asp-net-site-videos/how-do-i-use-routing-aspnet-web-forms)
 
 > [!div class="step-by-step"]
 > [Previous](aspnet-4-quick-hit-outbound-webforms-routing.md)

--- a/aspnet/web-forms/videos/net-4/routing/how-do-i-work-with-urls-in-aspnet-routing.md
+++ b/aspnet/web-forms/videos/net-4/routing/how-do-i-work-with-urls-in-aspnet-routing.md
@@ -4,7 +4,7 @@ title: "How Do I: Work with URLs in ASP.NET Routing? | Microsoft Docs"
 author: rick-anderson
 description: "In this video Chris Pels shows how to specify URLs in a web site that utilizes ASP.NET routing. First, a web site is created and routing is defined in the Gl..."
 ms.author: riande
-ms.date: 10/02/2024
+ms.date: 10/1/2024
 ms.assetid: 08f9d0a7-cfa0-4914-a672-8a64295d7ba8
 msc.legacyurl: /web-forms/videos/net-4/routing/how-do-i-work-with-urls-in-aspnet-routing
 msc.type: video

--- a/aspnet/web-forms/videos/net-4/routing/how-do-i-work-with-urls-in-aspnet-routing.md
+++ b/aspnet/web-forms/videos/net-4/routing/how-do-i-work-with-urls-in-aspnet-routing.md
@@ -4,7 +4,7 @@ title: "How Do I: Work with URLs in ASP.NET Routing? | Microsoft Docs"
 author: rick-anderson
 description: "In this video Chris Pels shows how to specify URLs in a web site that utilizes ASP.NET routing. First, a web site is created and routing is defined in the Gl..."
 ms.author: riande
-ms.date: 10/15/2010
+ms.date: 10/02/2024
 ms.assetid: 08f9d0a7-cfa0-4914-a672-8a64295d7ba8
 msc.legacyurl: /web-forms/videos/net-4/routing/how-do-i-work-with-urls-in-aspnet-routing
 msc.type: video
@@ -15,7 +15,7 @@ by [Chris Pels](https://twitter.com/chrispels)
 
 In this video Chris Pels shows how to specify URLs in a web site that utilizes ASP.NET routing. First, a web site is created and routing is defined in the Global Application Class (.asax). Next, a sample web page is created and a URL based upon a defined route is added to the page using the standard "hard coded" approach, e.g., "~/Stats/Visitors". Another link is then added to the page which dynamically generates the same URL in markup using the RouteValue method which accepts the route name and parameters. The same URL is then implemented using code rather than markup directly in the page. The original route and physical page location are then changed, resulting in the hard coded link no longer working whereas both dynamically generated links function properly. Finally, the value of dynamically generated links is then discussed.
 
-[&#9654; Watch video (20 minutes)](https://channel9.msdn.com/Blogs/ASP-NET-Site-Videos/how-do-i-work-with-urls-in-aspnet-routing)
+[&#9654; Watch video (20 minutes)](/shows/asp-net-site-videos/how-do-i-work-urls-in-aspnet-routing)
 
 > [!div class="step-by-step"]
 > [Previous](how-do-i-use-routing-with-aspnet-web-forms.md)

--- a/aspnet/web-forms/videos/net-4/routing/how-do-i-work-with-urls-in-aspnet-routing.md
+++ b/aspnet/web-forms/videos/net-4/routing/how-do-i-work-with-urls-in-aspnet-routing.md
@@ -4,7 +4,7 @@ title: "How Do I: Work with URLs in ASP.NET Routing? | Microsoft Docs"
 author: rick-anderson
 description: "In this video Chris Pels shows how to specify URLs in a web site that utilizes ASP.NET routing. First, a web site is created and routing is defined in the Gl..."
 ms.author: riande
-ms.date: 10/1/2024
+ms.date: 10/02/2024
 ms.assetid: 08f9d0a7-cfa0-4914-a672-8a64295d7ba8
 msc.legacyurl: /web-forms/videos/net-4/routing/how-do-i-work-with-urls-in-aspnet-routing
 msc.type: video
@@ -15,7 +15,7 @@ by [Chris Pels](https://twitter.com/chrispels)
 
 In this video Chris Pels shows how to specify URLs in a web site that utilizes ASP.NET routing. First, a web site is created and routing is defined in the Global Application Class (.asax). Next, a sample web page is created and a URL based upon a defined route is added to the page using the standard "hard coded" approach, e.g., "~/Stats/Visitors". Another link is then added to the page which dynamically generates the same URL in markup using the RouteValue method which accepts the route name and parameters. The same URL is then implemented using code rather than markup directly in the page. The original route and physical page location are then changed, resulting in the hard coded link no longer working whereas both dynamically generated links function properly. Finally, the value of dynamically generated links is then discussed.
 
-[&#9654; Watch video (20 minutes)](/shows/asp-net-site-videos/how-do-i-work-urls-in-aspnet-routing)
+[&#9654; Watch video (20 minutes)](https://learn.microsoft.com/shows/asp-net-site-videos/how-do-i-work-urls-in-aspnet-routing)
 
 > [!div class="step-by-step"]
 > [Previous](how-do-i-use-routing-with-aspnet-web-forms.md)


### PR DESCRIPTION
Fixes https://github.com/dotnet/AspNetCore.Docs/issues/33769

Videos for the net-4 web forms series moved from channel 9 to here:
learn.microsoft.com/shows/asp-net-site-videos/

This  UUF issue was supposed to be taken care of in August after I found where the videos have moved to but I missed it.  
So getting it in now since we already have the correct links.

NOTE:  Two of these videos cannot be launched from the relative link, which I verified is correct.  I ended up having to use a full link to them.

Tested all video links from build, they work. 