### PR TITLE
Remove link to contributor guide from the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
 # ASP.NET Docs
 
-This repository contains the conceptual ASP.NET 4.x documentation hosted in the [ASP.NET overview](https://learn.microsoft.com/aspnet/overview). See the [Contributing Guide](CONTRIBUTING.md) and the [issues list](https://github.com/dotnet/AspNetDocs/issues) if you would like to help out.
-
-API documentation changes should be made in the [ApiDocs repository](https://github.com/aspnet/ApiDocs) against the triple slash `///` comments.
+This repository contains the [conceptual ASP.NET 4.x documentation](https://learn.microsoft.com/aspnet/overview). API documentation is hosted in the [ApiDocs repository](https://github.com/aspnet/ApiDocs).


### PR DESCRIPTION

Fixes [#34457](https://github.com/dotnet/AspNetCore.Docs/issues/34457)
Removing link to Contributor guide, since it was written for ASP.NET Core, and we are not encouraging contributions to the ASP.NET 4.x documentation.