### PR TITLE
Xamarin references update

### DIFF
--- a/aspnet/mobile/overview.md
+++ b/aspnet/mobile/overview.md
@@ -19,10 +19,6 @@ msc.type: content
 
 In the first part of a two-part article, the authors explore some of the issues involved in creating a cloud back end that aggregates and processes data and serves it to mobile clients.
 
-[Part 2 - Build a Xamarin App with Authentication and Offline Support](https://msdn.microsoft.com/magazine/mt422581.aspx)
-
-In the second article in their series, the authors discuss how they use Xamarin to target multiple mobile client platforms, and show how to implement authentication and maintain a synchronized client-side cache of the data.
-
 ### [Calling Web API from a Windows Phone 8 Application](../web-api/overview/mobile-clients/calling-web-api-from-a-windows-phone-8-application.md)
 
 This end-to-end tutorial shows how to create an ASP.NET Web API application that provides data to a Windows Phone 8 application.

--- a/aspnet/visual-studio/overview/2013/release-notes.md
+++ b/aspnet/visual-studio/overview/2013/release-notes.md
@@ -380,6 +380,9 @@ The following code demonstrates how to enable CORS or JSONP in a SignalR 2.0 pro
 
 ### iOS and Android support via MonoTouch and MonoDroid
 
+> [!IMPORTANT]
+> Xamarin.Android, Xamarin.iOS, Xamarin.Mac are now integrated directly into .NET (starting with .NET 6) as .NET for Android, .NET for iOS, and .NET for macOS. If you're building with these project types today, they should be upgraded to .NET SDK-style projects for continued support. For more information about upgrading Xamarin projects to .NET, see the [Upgrade from Xamarin to .NET & .NET MAUI](/dotnet/maui/migration) documentation.
+
 Support has been added for iOS and Android clients using MonoTouch and MonoDroid components from the [Xamarin library](https://xamarin.com/). For more information on how to use them, see [Using Xamarin Components](https://github.com/SignalR/SignalR/wiki/Building-Mono.Mobile.sln). These components will be available in the [Xamarin Store](https://store.xamarin.com/) when the SignalR RTW release is available.
 
 <a id="portable"></a> ### Portable .NET client


### PR DESCRIPTION
Fixes dotnet/aspnetcore.docs#34326

Scanned for any reference to Xamarin and updated per guidelines.
There were only two topics to change.