### PR TITLE
Add more diagnostic sources to SignalR tracing doc

### DIFF
--- a/aspnet/signalr/overview/testing-and-debugging/enabling-signalr-tracing.md
+++ b/aspnet/signalr/overview/testing-and-debugging/enabling-signalr-tracing.md
@@ -70,6 +70,8 @@ The server event categories include the following sorts of messages:
 | SignalR.Transports.LongPollingTransport | LongPolling transport connection, disconnection, messaging, and error events |
 | SignalR.Transports.TransportHeartBeat | Transport connection, disconnection, and keepalive events |
 | SignalR.ReflectedHubDescriptorProvider | Hub discovery events |
+| SignalR.PresistentConnection | Connection handling events |
+| SignalR.HubDispatcher | Hub dispatching events |
 
 <a id="server_text"></a>
 ### Logging server events to text files

--- a/aspnet/signalr/overview/testing-and-debugging/enabling-signalr-tracing/samples/sample1.html
+++ b/aspnet/signalr/overview/testing-and-debugging/enabling-signalr-tracing/samples/sample1.html
@@ -50,6 +50,16 @@
           <add name="SignalR-Init" />
         </listeners>
       </source>
+      <source name="SignalR.PresistentConnection">
+        <listeners>
+          <add name="SignalR-Init" />
+        </listeners>
+      </source>
+      <source name="SignalR.HubDispatcher">
+        <listeners>
+          <add name="SignalR-Init" />
+        </listeners>
+      </source>
     </sources>
     <!-- Sets the trace verbosity level -->
     <switches>


### PR DESCRIPTION
There are a [few more source names](https://github.com/search?q=repo%3ASignalR%2FSignalR+%5B%22SignalR.&type=code) that we could add like "SignalR.Connection", but I think these are more obviously important enough to include in the doc.