### PR TITLE
Clarify OutputCache intent and limitations for classic ASP.Net.

### DIFF
--- a/aspnet/mvc/overview/older-versions-1/controllers-and-routing/improving-performance-with-output-caching-cs.md
+++ b/aspnet/mvc/overview/older-versions-1/controllers-and-routing/improving-performance-with-output-caching-cs.md
@@ -21,6 +21,9 @@ Imagine, for example, that your ASP.NET MVC application displays a list of datab
 
 If, on the other hand, you take advantage of the output cache then you can avoid executing a database query every time any user invokes the same controller action. The view can be retrieved from the cache instead of being regenerated from the controller action. Caching enables you to avoid performing redundant work on the server.
 
+> [!IMPORTANT]
+> Output caching is a performance optimization. The `VaryBy` settings (such as `VaryByParam`, `VaryByHeader`, and `VaryByCustom`) exist to cache alternate *representations* of a resource based on request characteristics — for example, a product page that varies by product ID, an agenda that varies by date, or content rendered in a different language. They are not a way to isolate audiences or classes of content. Don't rely on cache variation to separate personalized, tenant-specific, authorization-dependent, or otherwise sensitive responses; enforce any required isolation in your application, independently of cache configuration.
+
 ## Enabling Output Caching
 
 You enable output caching by adding an [OutputCache] attribute to either an individual controller action or an entire controller class. For example, the controller in Listing 1 exposes an action named Index(). The output of the Index() action is cached for 10 seconds.

--- a/aspnet/mvc/overview/older-versions-1/controllers-and-routing/improving-performance-with-output-caching-vb.md
+++ b/aspnet/mvc/overview/older-versions-1/controllers-and-routing/improving-performance-with-output-caching-vb.md
@@ -21,6 +21,9 @@ Imagine, for example, that your ASP.NET MVC application displays a list of datab
 
 If, on the other hand, you take advantage of the output cache then you can avoid executing a database query every time any user invokes the same controller action. The view can be retrieved from the cache instead of being regenerated from the controller action. Caching enables you to avoid performing redundant work on the server.
 
+> [!IMPORTANT]
+> Output caching is a performance optimization. The `VaryBy` settings (such as `VaryByParam`, `VaryByHeader`, and `VaryByCustom`) exist to cache alternate *representations* of a resource based on request characteristics — for example, a product page that varies by product ID, an agenda that varies by date, or content rendered in a different language. They are not a way to isolate audiences or classes of content. Don't rely on cache variation to separate personalized, tenant-specific, authorization-dependent, or otherwise sensitive responses; enforce any required isolation in your application, independently of cache configuration.
+
 #### Enabling Output Caching
 
 You enable output caching by adding an &lt;OutputCache&gt; attribute to either an individual controller action or an entire controller class. For example, the controller in Listing 1 exposes an action named Index(). The output of the Index() action is cached for 10 seconds.

--- a/aspnet/web-forms/overview/moving-to-aspnet-20/caching.md
+++ b/aspnet/web-forms/overview/moving-to-aspnet-20/caching.md
@@ -17,6 +17,9 @@ by [Microsoft](https://github.com/microsoft)
 
 An understanding of caching is important for a well-performing ASP.NET application. ASP.NET 1.x offered three different options for caching; output caching, fragment caching, and the cache API. ASP.NET 2.0 offers all three of these methods, but it adds some significant additional features. There are several new cache dependencies and developers now have the option to create custom cache dependencies as well. The configuration of caching has also been improved significantly in ASP.NET 2.0.
 
+> [!IMPORTANT]
+> Output caching is a performance optimization. The `@ OutputCache` directive and its `VaryBy` settings (such as `VaryByParam`, `VaryByHeader`, and `VaryByCustom`) exist to cache alternate *representations* of a page based on request characteristics — for example, a product page that varies by product ID, an agenda that varies by date, or content rendered in a different language. They are not a way to isolate audiences or classes of content. Don't rely on cache variation to separate personalized, tenant-specific, authorization-dependent, or otherwise sensitive responses; enforce any required isolation in your application, independently of cache configuration.
+
 ## New Features
 
 ## Cache Profiles

--- a/aspnet/whitepapers/aspnet4/overview.md
+++ b/aspnet/whitepapers/aspnet4/overview.md
@@ -122,6 +122,9 @@ Specifying a different output cache provider for an HTTP request requires a litt
 
 With the addition of output-cache provider extensibility to ASP.NET 4, you can now pursue more aggressive and more intelligent output-caching strategies for your Web sites. For example, it is now possible to cache the "Top 10" pages of a site in memory, while caching pages that get lower traffic on disk. Alternatively, you can cache every vary-by combination for a rendered page, but use a distributed cache so that the memory consumption is offloaded from front-end Web servers.
 
+> [!IMPORTANT]
+> Output caching, including custom output-cache providers and any `VaryBy` combinations, is a performance optimization that stores alternate *representations* of a resource. It is not a way to isolate audiences or classes of content. Don't rely on cache variation or provider selection to separate personalized, tenant-specific, authorization-dependent, or otherwise sensitive responses; enforce any required isolation in your application, independently of cache configuration.
+
 <a id="0.2__Toc224729020"></a><a id="0.2__Toc253429241"></a><a id="0.2__Toc243304615"></a>
 
 ### Auto-Start Web Applications


### PR DESCRIPTION
This pull request adds important clarifications about the use of output caching in several ASP.NET documentation files. The main update is a warning to developers that output caching and its variation settings are intended for optimizing performance by storing alternate representations of resources, not for isolating audiences or protecting sensitive content. The warning emphasizes that any required isolation for personalized or sensitive data must be enforced in the application itself, not through cache configuration.

**Documentation improvements:**

* Added a warning to the ASP.NET MVC (C# and VB) output caching documentation explaining that `VaryBy` settings (like `VaryByParam`, `VaryByHeader`, and `VaryByCustom`) are for caching alternate representations, not for isolating personalized or sensitive content, and that application-level isolation is still required (`improving-performance-with-output-caching-cs.md`, `improving-performance-with-output-caching-vb.md`). [[1]](diffhunk://#diff-aab0936bb7b2976060c41e1f4578c25df34f9375e73ed083f93b5a4d94628c06R24-R26) [[2]](diffhunk://#diff-3744aba8094597e4d4727d7f592181ede329d71e58b6dcf2cb093ad8b1bb51fcR24-R26)
* Added a similar warning to the ASP.NET Web Forms caching documentation, clarifying the purpose of the `@ OutputCache` directive and its `VaryBy` settings (`caching.md`).
* Updated the ASP.NET 4 whitepaper to include a warning that custom output-cache providers and `VaryBy` combinations are not suitable for isolating sensitive or personalized responses, and that proper isolation must be handled in the application (`overview.md`).
<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->